### PR TITLE
ETL-188: Bind NATS stream names with pipeline id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+# NATS port configuration variable
+NATS_PORT ?= 4222
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -98,7 +100,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go --nats-addr localhost:4223
+	go run ./cmd/main.go --nats-addr localhost:$(NATS_PORT)	
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
## Description
1. Use suffix with pipeline id in the stream name of the ingestor
2. Simplify NATS streams clean up
3. In the terminate firstly remove namespace with pods and after that streams.
4. Remove DLQ stream separately (DLQ stream removal could be possible evicted from NATS clean up part in future due to it's date might be important to the customer)

## Example
1. Create pipeline
```
sh
petrnuzhnov ~  $ curl 'http://localhost:8080/api/v1/pipeline' -X 'POST' --data-raw '{"pipeline_id":"uuid-test-demo-pipeline-1","source":{"type":"kafka","connection_params":{"brokers":["kafka-chart.kafka.svc.cluster.local:9092"],"protocol":"SASL_PLAINTEXT","mechanism":"PLAIN","username":"admin","password":"admin"},"topics":[{"consumer_group_initial_offset":"latest","name":"users","schema":{"type":"json","fields":[{"name":"user_id","type":"string"},{"name":"name","type":"string"}]},"deduplication":{"enabled":false}},{"consumer_group_initial_offset":"latest","name":"emails","schema":{"type":"json","fields":[{"name":"user_id","type":"string"},{"name":"email","type":"string"}]},"deduplication":{"enabled":false}}]},"join":{"enabled":true,"type":"temporal","sources":[{"source_id":"users","join_key":"user_id","time_window":"1h","orientation":"left"},{"source_id":"emails","join_key":"user_id","time_window":"1h","orientation":"right"}]},"sink":{"type":"clickhouse","host":"clickhouse-chart.clickhouse.svc.cluster.local","port":"9000","database":"default","username":"admin","password":"admin","secure":false,"max_batch_size":1000,"max_delay_time":"30s","table":"users_dedup","table_mapping":[{"source_id":"users","field_name":"user_id","column_name":"user_id","column_type":"string"},{"source_id":"users","field_name":"name","column_name":"name","column_type":"String"},{"source_id":"emails","field_name":"email","column_name":"email","column_type":"String"}]}}'
```
2. check status
```
sh
petrnuzhnov ~  $ curl 'http://localhost:8080/api/v1/pipeline'
[{"pipeline_id":"uuid-test-demo-pipeline-1","name":"","transformation_type":"Join","created_at":"2025-08-21T12:57:42.721376Z","state":"","status":"Running"}]%    
```

3. Check NATS streams and pipeline CR in k8s
```
sh
petrnuzhnov ~  $ nats stream ls
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                     Streams                                                     │
├────────────────────────────────────────────┬─────────────┬─────────────────────┬──────────┬──────┬──────────────┤
│ Name                                       │ Description │ Created             │ Messages │ Size │ Last Message │
├────────────────────────────────────────────┼─────────────┼─────────────────────┼──────────┼──────┼──────────────┤
│ emails-uuid-test-demo-pipeline-1           │             │ 2025-08-21 14:51:03 │ 0        │ 0 B  │ never        │
│ gf-stream-joined-uuid-test-demo-pipeline-1 │             │ 2025-08-21 14:51:03 │ 0        │ 0 B  │ never        │
│ users-uuid-test-demo-pipeline-1            │             │ 2025-08-21 14:51:03 │ 0        │ 0 B  │ never        │
│ uuid-test-demo-pipeline-1-DLQ              │             │ 2025-08-21 14:51:03 │ 0        │ 0 B  │ never        │
╰────────────────────────────────────────────┴─────────────┴─────────────────────┴──────────┴──────┴──────────────╯                         

petrnuzhnov ~  $ kubectl get pipelines
NAME                        AGE
uuid-test-demo-pipeline-1   15s

petrnuzhnov ~  $ kubectl get pods -n pipeline-uuid-test-demo-pipeline-1
NAME                          READY   STATUS    RESTARTS   AGE
ingestor-0-86c866944d-5tgv2   1/1     Running   0          20s
ingestor-1-5dbc96b669-jmqhg   1/1     Running   0          20s
join-6cd66f76c8-chpqz         1/1     Running   0          20s
sink-9d587fc94-rx2jl          1/1     Running   0          20s
```

4. Delete pipeline
```
sh
petrnuzhnov ~ $ curl 'http://localhost:8080/api/v1/pipeline/uuid-test-demo-pipeline-1/terminate' -X 'DELETE'
```

5. Check pipeline status
```
sh
petrnuzhnov ~ $ curl 'http://localhost:8080/api/v1/pipeline'
[{"pipeline_id":"uuid-test-demo-pipeline-1","name":"","transformation_type":"Join","created_at":"2025-08-21T12:57:42.721376Z","state":"","status":"Terminated"}]%
```

6. Check NATS streams
```
sh
petrnuzhnov ~/code/tmp/glassflow-cloud  $ nats stream ls -a
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                        Streams                                                       │
├────────────────────────┬───────────────────────────────────┬─────────────────────┬──────────┬─────────┬──────────────┤
│ Name                   │ Description                       │ Created             │ Messages │ Size    │ Last Message │
├────────────────────────┼───────────────────────────────────┼─────────────────────┼──────────┼─────────┼──────────────┤
│ KV_glassflow-pipelines │ Store for all glassflow pipelines │ 2025-08-21 12:55:17 │ 4        │ 2.6 KiB │ 13m56s       │
╰────────────────────────┴───────────────────────────────────┴─────────────────────┴──────────┴─────────┴──────────────╯
```
