### PR TITLE
fix: NATS streams cleanup

### DIFF
--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -669,7 +669,7 @@ func (r *PipelineReconciler) cleanupNATSPipelineJoinKeyValueStore(ctx context.Co
 
 	if r.NATSClient == nil {
 		log.Info("NATS client not available, skipping key value store cleanup")
-		return nil
+		return fmt.Errorf("NATS client not available, skipping NATS cleanup")
 	}
 
 	// since join key value names are same as stream names in CH-ETL
@@ -677,7 +677,7 @@ func (r *PipelineReconciler) cleanupNATSPipelineJoinKeyValueStore(ctx context.Co
 		err := r.NATSClient.JetStream().DeleteKeyValue(ctx, stream.OutputStream)
 		if err != nil {
 			log.Error(err, "failed to delete join key-value store", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
-			return nil
+			return fmt.Errorf("failed to delete NATS KV Store: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Changes from #4 are included

NATS stream cleanup logic needs to be changed due to new stream name changes

Streams are now cleaned using pipeline spec
In case of join the key value store associated is also removed
Pipeline object is kept as is with terminated status

1. Created pipeline

```sh
kiran@kirans-MacBook-Pro glassflow-api % nats stream list
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│                                          Streams                                         │
├─────────────────────┬─────────────┬─────────────────────┬──────────┬──────┬──────────────┤
│ Name                │ Description │ Created             │ Messages │ Size │ Last Message │
├─────────────────────┼─────────────┼─────────────────────┼──────────┼──────┼──────────────┤
│ gf-cdd92700-DLQ     │             │ 2025-08-29 01:45:49 │ 0        │ 0 B  │ never        │
│ gf-cdd92700-joined  │             │ 2025-08-29 01:45:49 │ 0        │ 0 B  │ never        │
│ gf-cdd92700-users   │             │ 2025-08-29 01:45:49 │ 0        │ 0 B  │ never        │
│ gf-cdd92700-users_2 │             │ 2025-08-29 01:45:49 │ 0        │ 0 B  │ never        │
╰─────────────────────┴─────────────┴─────────────────────┴──────────┴──────┴──────────────╯


kiran@kirans-MacBook-Pro glassflow-api % nats kv list    
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                Key-Value Buckets                                               │
├─────────────────────┬───────────────────────────────────┬─────────────────────┬─────────┬────────┬─────────────┤
│ Bucket              │ Description                       │ Created             │ Size    │ Values │ Last Update │
├─────────────────────┼───────────────────────────────────┼─────────────────────┼─────────┼────────┼─────────────┤
│ gf-cdd92700-users   │                                   │ 2025-08-29 01:45:51 │ 0 B     │ 0      │ never       │
│ gf-cdd92700-users_2 │                                   │ 2025-08-29 01:45:51 │ 0 B     │ 0      │ never       │
│ glassflow-pipelines │ Store for all glassflow pipelines │ 2025-08-29 01:45:44 │ 3.4 KiB │ 1      │ 28.39s      │
╰─────────────────────┴───────────────────────────────────┴─────────────────────┴─────────┴────────┴─────────────╯
```


2. Terminated pipeline
```sh
kiran@kirans-MacBook-Pro glassflow-api % nats stream list
No Streams defined, pass -a to include system streams
kiran@kirans-MacBook-Pro glassflow-api % nats kv list                                              
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                Key-Value Buckets                                               │
├─────────────────────┬───────────────────────────────────┬─────────────────────┬─────────┬────────┬─────────────┤
│ Bucket              │ Description                       │ Created             │ Size    │ Values │ Last Update │
├─────────────────────┼───────────────────────────────────┼─────────────────────┼─────────┼────────┼─────────────┤
│ glassflow-pipelines │ Store for all glassflow pipelines │ 2025-08-29 01:45:44 │ 3.4 KiB │ 1      │ 13m21s      │
╰─────────────────────┴───────────────────────────────────┴─────────────────────┴─────────┴────────┴─────────────╯
```