### PR TITLE
feat: ETL-331: operator should set component resource values from HELM chart

### DIFF
--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -43,6 +43,30 @@ spec:
           value: {{ .Values.componentImages.join.repository }}:{{ .Values.componentImages.join.tag }}
         - name: SINK_IMAGE
           value: {{ .Values.componentImages.sink.repository }}:{{ .Values.componentImages.sink.tag }}
+        - name: INGESTOR_CPU_REQUEST
+          value: {{ .Values.componentResources.ingestor.requests.cpu | quote }}
+        - name: INGESTOR_CPU_LIMIT
+          value: {{ .Values.componentResources.ingestor.limits.cpu | quote }}
+        - name: INGESTOR_MEMORY_REQUEST
+          value: {{ .Values.componentResources.ingestor.requests.memory | quote }}
+        - name: INGESTOR_MEMORY_LIMIT
+          value: {{ .Values.componentResources.ingestor.limits.memory | quote }}
+        - name: JOIN_CPU_REQUEST
+          value: {{ .Values.componentResources.join.requests.cpu | quote }}
+        - name: JOIN_CPU_LIMIT
+          value: {{ .Values.componentResources.join.limits.cpu | quote }}
+        - name: JOIN_MEMORY_REQUEST
+          value: {{ .Values.componentResources.join.requests.memory | quote }}
+        - name: JOIN_MEMORY_LIMIT
+          value: {{ .Values.componentResources.join.limits.memory | quote }}
+        - name: SINK_CPU_REQUEST
+          value: {{ .Values.componentResources.sink.requests.cpu | quote }}
+        - name: SINK_CPU_LIMIT
+          value: {{ .Values.componentResources.sink.limits.cpu | quote }}
+        - name: SINK_MEMORY_REQUEST
+          value: {{ .Values.componentResources.sink.requests.memory | quote }}
+        - name: SINK_MEMORY_LIMIT
+          value: {{ .Values.componentResources.sink.limits.memory | quote }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
         livenessProbe:

--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -37,6 +37,30 @@ componentImages:
     repository: ghcr.io/glassflow/glassflow-etl-sink
     tag: stable
 
+# Component resource configurations
+componentResources:
+  ingestor:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 1500m
+      memory: 1.5Gi
+  join:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 1500m
+      memory: 1.5Gi
+  sink:
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+    limits:
+      cpu: 1500m
+      memory: 1.5Gi
+
 
 metricsService:
   ports:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,6 +112,53 @@ func main() {
 		"SINK_IMAGE", "ghcr.io/glassflow/glassflow-etl-sink:latest"),
 		"Image for the sink component")
 
+	// Component resource configuration
+	var ingestorCPURequest, ingestorCPULimit, ingestorMemoryRequest, ingestorMemoryLimit string
+	var joinCPURequest, joinCPULimit, joinMemoryRequest, joinMemoryLimit string
+	var sinkCPURequest, sinkCPULimit, sinkMemoryRequest, sinkMemoryLimit string
+
+	// Ingestor resources
+	flag.StringVar(&ingestorCPURequest, "ingestor-cpu-request", getEnvOrDefault(
+		"INGESTOR_CPU_REQUEST", "100m"),
+		"CPU request for ingestor component")
+	flag.StringVar(&ingestorCPULimit, "ingestor-cpu-limit", getEnvOrDefault(
+		"INGESTOR_CPU_LIMIT", "150m"),
+		"CPU limit for ingestor component")
+	flag.StringVar(&ingestorMemoryRequest, "ingestor-memory-request", getEnvOrDefault(
+		"INGESTOR_MEMORY_REQUEST", "128Mi"),
+		"Memory request for ingestor component")
+	flag.StringVar(&ingestorMemoryLimit, "ingestor-memory-limit", getEnvOrDefault(
+		"INGESTOR_MEMORY_LIMIT", "512Mi"),
+		"Memory limit for ingestor component")
+
+	// Join resources
+	flag.StringVar(&joinCPURequest, "join-cpu-request", getEnvOrDefault(
+		"JOIN_CPU_REQUEST", "100m"),
+		"CPU request for join component")
+	flag.StringVar(&joinCPULimit, "join-cpu-limit", getEnvOrDefault(
+		"JOIN_CPU_LIMIT", "150m"),
+		"CPU limit for join component")
+	flag.StringVar(&joinMemoryRequest, "join-memory-request", getEnvOrDefault(
+		"JOIN_MEMORY_REQUEST", "128Mi"),
+		"Memory request for join component")
+	flag.StringVar(&joinMemoryLimit, "join-memory-limit", getEnvOrDefault(
+		"JOIN_MEMORY_LIMIT", "512Mi"),
+		"Memory limit for join component")
+
+	// Sink resources
+	flag.StringVar(&sinkCPURequest, "sink-cpu-request", getEnvOrDefault(
+		"SINK_CPU_REQUEST", "100m"),
+		"CPU request for sink component")
+	flag.StringVar(&sinkCPULimit, "sink-cpu-limit", getEnvOrDefault(
+		"SINK_CPU_LIMIT", "150m"),
+		"CPU limit for sink component")
+	flag.StringVar(&sinkMemoryRequest, "sink-memory-request", getEnvOrDefault(
+		"SINK_MEMORY_REQUEST", "512Mi"),
+		"Memory request for sink component")
+	flag.StringVar(&sinkMemoryLimit, "sink-memory-limit", getEnvOrDefault(
+		"SINK_MEMORY_LIMIT", "1Gi"),
+		"Memory limit for sink component")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -240,13 +287,25 @@ func main() {
 	}
 
 	if err = (&controller.PipelineReconciler{
-		Client:            mgr.GetClient(),
-		Scheme:            mgr.GetScheme(),
-		NATSClient:        natsClient,
-		ComponentNATSAddr: natsComponentAddr,
-		IngestorImage:     ingestorImage,
-		JoinImage:         joinImage,
-		SinkImage:         sinkImage,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		NATSClient:            natsClient,
+		ComponentNATSAddr:     natsComponentAddr,
+		IngestorImage:         ingestorImage,
+		JoinImage:             joinImage,
+		SinkImage:             sinkImage,
+		IngestorCPURequest:    ingestorCPURequest,
+		IngestorCPULimit:      ingestorCPULimit,
+		IngestorMemoryRequest: ingestorMemoryRequest,
+		IngestorMemoryLimit:   ingestorMemoryLimit,
+		JoinCPURequest:        joinCPURequest,
+		JoinCPULimit:          joinCPULimit,
+		JoinMemoryRequest:     joinMemoryRequest,
+		JoinMemoryLimit:       joinMemoryLimit,
+		SinkCPURequest:        sinkCPURequest,
+		SinkCPULimit:          sinkCPULimit,
+		SinkMemoryRequest:     sinkMemoryRequest,
+		SinkMemoryLimit:       sinkMemoryLimit,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pipeline")
 		os.Exit(1)

--- a/internal/controller/component_deployment.go
+++ b/internal/controller/component_deployment.go
@@ -12,11 +12,16 @@ type containerBuilder interface {
 	withImage(image string) containerBuilder
 	withVolumeMount(mount v1.VolumeMount) containerBuilder
 	withEnv(env []v1.EnvVar) containerBuilder
+	withResources(cpuRequest, cpuLimit, memoryRequest, memoryLimit string) containerBuilder
 	build() *v1.Container
 }
 
 type componentContainer struct {
-	con *v1.Container
+	con           *v1.Container
+	cpuRequest    string
+	cpuLimit      string
+	memoryRequest string
+	memoryLimit   string
 }
 
 func newComponentContainerBuilder() *componentContainer {
@@ -52,17 +57,31 @@ func (c *componentContainer) withName(name string) containerBuilder {
 	return c
 }
 
+// withResources implements containerBuilder.
+func (c *componentContainer) withResources(cpuRequest, cpuLimit, memoryRequest, memoryLimit string) containerBuilder {
+	c.cpuRequest = cpuRequest
+	c.cpuLimit = cpuLimit
+	c.memoryRequest = memoryRequest
+	c.memoryLimit = memoryLimit
+	return c
+}
+
 // build implements containerBuilder.
 func (c *componentContainer) build() *v1.Container {
-	// TODO: see what other common params must be set
+	// Parse resource strings and create resource requirements
+	cpuRequest, _ := resource.ParseQuantity(c.cpuRequest)
+	cpuLimit, _ := resource.ParseQuantity(c.cpuLimit)
+	memoryRequest, _ := resource.ParseQuantity(c.memoryRequest)
+	memoryLimit, _ := resource.ParseQuantity(c.memoryLimit)
+
 	c.con.Resources = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
-			v1.ResourceCPU:    *resource.NewMilliQuantity(125, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+			v1.ResourceCPU:    cpuLimit,
+			v1.ResourceMemory: memoryLimit,
 		},
 		Requests: v1.ResourceList{
-			v1.ResourceCPU:    *resource.NewMilliQuantity(125, resource.DecimalSI),
-			v1.ResourceMemory: *resource.NewQuantity(100*1024*1024, resource.BinarySI),
+			v1.ResourceCPU:    cpuRequest,
+			v1.ResourceMemory: memoryRequest,
 		},
 	}
 	// TODO: Make it configurable may be?

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -63,6 +63,19 @@ type PipelineReconciler struct {
 	IngestorImage string
 	JoinImage     string
 	SinkImage     string
+	// Component resource configurations
+	IngestorCPURequest    string
+	IngestorCPULimit      string
+	IngestorMemoryRequest string
+	IngestorMemoryLimit   string
+	JoinCPURequest        string
+	JoinCPULimit          string
+	JoinMemoryRequest     string
+	JoinMemoryLimit       string
+	SinkCPURequest        string
+	SinkCPULimit          string
+	SinkMemoryRequest     string
+	SinkMemoryLimit       string
 }
 
 // -------------------------------------------------------------------------------------------------------------------
@@ -635,6 +648,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 				{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 				{Name: "GLASSFLOW_INGESTOR_TOPIC", Value: t.TopicName},
 			}).
+			withResources(r.IngestorCPURequest, r.IngestorCPULimit, r.IngestorMemoryRequest, r.IngestorMemoryLimit).
 			build()
 
 		deployment := newComponentDeploymentBuilder().
@@ -682,6 +696,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.ComponentNATSAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 		}).
+		withResources(r.JoinCPURequest, r.JoinCPULimit, r.JoinMemoryRequest, r.JoinMemoryLimit).
 		build()
 
 	deployment := newComponentDeploymentBuilder().
@@ -728,6 +743,7 @@ func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.ComponentNATSAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 		}).
+		withResources(r.SinkCPURequest, r.SinkCPULimit, r.SinkMemoryRequest, r.SinkMemoryLimit).
 		build()
 
 	deployment := newComponentDeploymentBuilder().


### PR DESCRIPTION
Changes:
1. Added cpu & memory, requests & limits in component_resources section in operator chart
2.  Added defaults if these values are not present


### Created pipeline
```sh
 % curl -v 'http://localhost:8085/api/v1/pipeline' -X POST --data-raw '{"pipeline_id": "kiran-dedup-k8-1", "name": "k8 without join, testing pause/resume 3 replica", "source": {"type": "kafka", "provider": "custom", "connection_params": {"brokers": ["kafka.default.svc.cluster.local:9092"], "protocol": "PLAINTEXT", "skip_auth": true}, "topics": [{"consumer_group_initial_offset": "latest", "name": "users", "id": "users", "replicas": 3, "schema": {"type": "json", "fields": [{"name": "event_id", "type": "string"}, {"name": "user.id", "type": "string"}, {"name": "user.name", "type": "string"}, {"name": "user.email", "type": "string"}, {"name": "created_at", "type": "string"}]}, "deduplication": {"enabled": false, "id_field": "event_id", "id_field_type": "string", "time_window": "1m"}}]}, "sink": {"type": "clickhouse", "provider": "custom", "host": "my-release-clickhouse.default.svc.cluster.local", "port": "9000", "http_port": "8123", "database": "default", "username": "default", "password": "cXZiZVNJM0ZLeg==", "secure": false, "skip_certificate_verification": true, "max_batch_size": 1000, "max_delay_time": "5s", "table": "users_dedup", "table_mapping": [{"source_id": "users", "field_name": "event_id", "column_name": "event_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.id", "column_name": "user_id", "column_type": "String"}, {"source_id": "users", "field_name": "user.name", "column_name": "name", "column_type": "String"}, {"source_id": "users", "field_name": "user.email", "column_name": "email", "column_type": "String"}, {"source_id": "users", "field_name": "created_at", "column_name": "created_at", "column_type": "DateTime"}]}}'
```


### checked pod config for ingestor in cluster
```yaml
      allocatedResources:
        cpu: 100m
        memory: 512Mi
      resources:
        limits:
          cpu: 150m
          memory: 1Gi
        requests:
          cpu: 100m
          memory: 512Mi
```


### checked pod config for sink in cluster
```yaml
      allocatedResources:
        cpu: 100m
        memory: 128Mi
      resources:
        limits:
          cpu: 150m
          memory: 512Mi
        requests:
          cpu: 100m
          memory: 128Mi
```


These are as per default values. 
Once merged can check with HELM chart with values  set by @ashish-bagri 