### PR TITLE
ETL-324: refactor release and operator image build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,16 +1,33 @@
 name: Merge to Main
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
+  check-merge:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      should-build: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
+    steps:
+      - name: Check if PR has no-build label
+        run: |
+          if [ "${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}" = "true" ]; then
+            echo "✅ PR does not have 'no-build' label - proceeding with build"
+          else
+            echo "❌ PR has 'no-build' label - skipping build"
+          fi
+
   test-operator:
+    needs: [check-merge]
+    if: needs.check-merge.outputs.should-build
     uses: ./.github/workflows/test-operator.yml
 
   build-operator-image:
     needs: [test-operator]
+    if: needs.check-merge.outputs.should-build
     uses: ./.github/workflows/build-image.yml
     with:
       push: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,6 +28,7 @@ jobs:
     uses: ./.github/workflows/test-operator.yml
   build-operator-image:
     needs: [test-operator]
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-build') }}
     uses: ./.github/workflows/build-image.yml
     with:
       push: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,6 +17,24 @@ jobs:
       version_tag: ${{ github.ref_name }}
     secrets: inherit
 
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-operator-image]
+    permissions:
+      contents: write
+    steps:
+      - name: Create Release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   chart-app-version-bump:
     needs: [build-operator-image]
     uses: ./.github/workflows/chart-app-version-bump.yml


### PR DESCRIPTION
changes:
1. Create a release on tag push
2. if no-build label added to PR, skip operator build job