### PR TITLE
feat: set NATS stream age and size from charts, pass it to components

### DIFF
--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
           value: {{ .Values.glassflowComponents.join.image.tag | quote }}
         - name: SINK_IMAGE_TAG
           value: {{ .Values.glassflowComponents.sink.image.tag | quote }}
+        - name: NATS_MAX_STREAM_AGE
+          value: {{ .Values.nats.stream.maxAge | quote }}
+        - name: NATS_MAX_STREAM_BYTES
+          value: {{ .Values.nats.stream.maxBytes | quote }}
         image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
         livenessProbe:

--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -97,3 +97,6 @@ metricsService:
 nats:
   address: ""
   componentAddress: ""
+  stream:
+    maxAge: "7d"
+    maxBytes: "100GB"

--- a/internal/controller/pipeline_controller.go
+++ b/internal/controller/pipeline_controller.go
@@ -40,6 +40,7 @@ import (
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/status"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/utils"
 )
 
 // -------------------------------------------------------------------------------------------------------------------
@@ -92,6 +93,9 @@ type PipelineReconciler struct {
 	Scheme            *runtime.Scheme
 	NATSClient        *nats.NATSClient
 	ComponentNATSAddr string
+	// NATS stream configurations
+	NATSMaxStreamAge   string
+	NATSMaxStreamBytes string
 	// Component image configurations
 	IngestorImage string
 	JoinImage     string
@@ -927,6 +931,8 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 				{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 				{Name: "GLASSFLOW_INGESTOR_TOPIC", Value: t.TopicName},
 				{Name: "GLASSFLOW_LOG_LEVEL", Value: r.IngestorLogLevel},
+				{Name: "GLASSFLOW_NATS_MAX_STREAM_AGE", Value: r.NATSMaxStreamAge},
+				{Name: "GLASSFLOW_NATS_MAX_STREAM_BYTES", Value: utils.ConvertBytesToString(r.NATSMaxStreamBytes)},
 
 				{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 				{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
@@ -990,6 +996,8 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.ComponentNATSAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.JoinLogLevel},
+			{Name: "GLASSFLOW_NATS_MAX_STREAM_AGE", Value: r.NATSMaxStreamAge},
+			{Name: "GLASSFLOW_NATS_MAX_STREAM_BYTES", Value: utils.ConvertBytesToString(r.NATSMaxStreamBytes)},
 
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 			{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
@@ -1052,6 +1060,8 @@ func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.ComponentNATSAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.SinkLogLevel},
+			{Name: "GLASSFLOW_NATS_MAX_STREAM_AGE", Value: r.NATSMaxStreamAge},
+			{Name: "GLASSFLOW_NATS_MAX_STREAM_BYTES", Value: utils.ConvertBytesToString(r.NATSMaxStreamBytes)},
 
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 			{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -10,7 +10,8 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 )
 
-const StreamMaxAge = 24 * time.Hour // 24 hours
+const DefaultStreamMaxAge = 168 * time.Hour       // 7 days
+const DefaultStreamMaxBytes = int64(107374182400) // 100GB
 
 // PipelineStatus represents the overall status of a pipeline
 type PipelineStatus string
@@ -51,11 +52,17 @@ type PipelineConfig struct {
 }
 
 type NATSClient struct {
-	nc *nats.Conn
-	js jetstream.JetStream
+	nc       *nats.Conn
+	js       jetstream.JetStream
+	maxAge   time.Duration
+	maxBytes int64
 }
 
 func New(url string) (*NATSClient, error) {
+	return NewWithStreamConfig(url, DefaultStreamMaxAge, DefaultStreamMaxBytes)
+}
+
+func NewWithStreamConfig(url string, maxAge time.Duration, maxBytes int64) (*NATSClient, error) {
 	nc, err := nats.Connect(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to NATS: %w", err)
@@ -67,8 +74,10 @@ func New(url string) (*NATSClient, error) {
 	}
 
 	return &NATSClient{
-		nc: nc,
-		js: js,
+		nc:       nc,
+		js:       js,
+		maxAge:   maxAge,
+		maxBytes: maxBytes,
 	}, nil
 }
 
@@ -80,7 +89,8 @@ func (n *NATSClient) CreateOrUpdateStream(ctx context.Context, name string, dedu
 		Storage:  jetstream.FileStorage,
 
 		Retention: jetstream.LimitsPolicy,
-		MaxAge:    StreamMaxAge,
+		MaxAge:    n.maxAge,
+		MaxBytes:  n.maxBytes,
 		Discard:   jetstream.DiscardOld,
 	}
 

--- a/internal/utils/bytes.go
+++ b/internal/utils/bytes.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseBytes parses a byte string that can be either a number or human-readable format (e.g., "100GB", "1TB")
+func ParseBytes(s string) (int64, error) {
+	// First try to parse as a plain number
+	if bytes, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return bytes, nil
+	}
+
+	// Handle human-readable formats
+	s = strings.ToUpper(strings.TrimSpace(s))
+
+	var multiplier int64 = 1
+	var numStr string
+
+	if strings.HasSuffix(s, "KB") {
+		multiplier = 1024
+		numStr = strings.TrimSuffix(s, "KB")
+	} else if strings.HasSuffix(s, "MB") {
+		multiplier = 1024 * 1024
+		numStr = strings.TrimSuffix(s, "MB")
+	} else if strings.HasSuffix(s, "GB") {
+		multiplier = 1024 * 1024 * 1024
+		numStr = strings.TrimSuffix(s, "GB")
+	} else if strings.HasSuffix(s, "TB") {
+		multiplier = 1024 * 1024 * 1024 * 1024
+		numStr = strings.TrimSuffix(s, "TB")
+	} else {
+		return 0, fmt.Errorf("invalid byte format: %s", s)
+	}
+
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number in byte format: %s", s)
+	}
+
+	return int64(num * float64(multiplier)), nil
+}
+
+// ConvertBytesToString converts human-readable byte format to numeric string for components
+func ConvertBytesToString(bytesStr string) string {
+	// First try to parse as a plain number
+	if _, err := strconv.ParseInt(bytesStr, 10, 64); err == nil {
+		return bytesStr // Already a numeric string
+	}
+
+	// Handle human-readable formats
+	s := strings.ToUpper(strings.TrimSpace(bytesStr))
+
+	var multiplier int64 = 1
+	var numStr string
+
+	if strings.HasSuffix(s, "KB") {
+		multiplier = 1024
+		numStr = strings.TrimSuffix(s, "KB")
+	} else if strings.HasSuffix(s, "MB") {
+		multiplier = 1024 * 1024
+		numStr = strings.TrimSuffix(s, "MB")
+	} else if strings.HasSuffix(s, "GB") {
+		multiplier = 1024 * 1024 * 1024
+		numStr = strings.TrimSuffix(s, "GB")
+	} else if strings.HasSuffix(s, "TB") {
+		multiplier = 1024 * 1024 * 1024 * 1024
+		numStr = strings.TrimSuffix(s, "TB")
+	} else {
+		// If we can't parse it, return the default
+		return "107374182400" // 100GB default
+	}
+
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		// If we can't parse the number, return the default
+		return "107374182400" // 100GB default
+	}
+
+	return strconv.FormatInt(int64(num*float64(multiplier)), 10)
+}


### PR DESCRIPTION
Changes:
1. Get NATS stream age and size from charts and pass it to components
2. Linked to https://github.com/glassflow/clickhouse-etl/pull/252