### PR TITLE
fix: values.yaml remove extra new lines

### DIFF
--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -85,8 +85,6 @@ glassflowComponents:
     # Node affinity for sink component (optional)
     affinity: {}
 
-
-
 nats:
   address: ""
   stream:


### PR DESCRIPTION
Change:
1. Fixed linting error, extra new lines


## Run chart-testing
```sh
 % /opt/homebrew/bin/ct lint --config ct.yaml
Linting charts...
Version increment checking disabled.
>>> helm version --template {{ .Version }}

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 glassflow-operator => (version: "0.5.5", path: "charts/glassflow-operator")
------------------------------------------------------------------------------------------------------------------------

>>> helm dependency build charts/glassflow-operator
Linting chart "glassflow-operator => (version: \"0.5.5\", path: \"charts/glassflow-operator\")"
>>> yamale --schema /opt/homebrew/etc/ct/chart_schema.yaml charts/glassflow-operator/Chart.yaml
Validating charts/glassflow-operator/Chart.yaml...
Validation success! 👍
>>> yamllint --config-file /opt/homebrew/etc/ct/lintconf.yaml charts/glassflow-operator/Chart.yaml
>>> yamllint --config-file /opt/homebrew/etc/ct/lintconf.yaml charts/glassflow-operator/values.yaml
Validating maintainers...
>>> git ls-remote --get-url origin
>>> helm lint charts/glassflow-operator
==> Linting charts/glassflow-operator
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ glassflow-operator => (version: "0.5.5", path: "charts/glassflow-operator")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```