### PR TITLE
ETL-588: feat: chart changes for making component image pull policy configurable

### DIFF
--- a/charts/glassflow-operator/templates/configmap.yaml
+++ b/charts/glassflow-operator/templates/configmap.yaml
@@ -43,6 +43,10 @@ data:
   SINK_IMAGE_TAG: {{ .Values.glassflowComponents.sink.image.tag | quote }}
   OPERATOR_IMAGE_TAG: {{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion | quote }}
   DEDUP_IMAGE_TAG: {{ .Values.glassflowComponents.dedup.image.tag | quote }}
+  INGESTOR_PULL_POLICY: {{ .Values.glassflowComponents.ingestor.image.pullPolicy | default "IfNotPresent" | quote }}
+  JOIN_PULL_POLICY: {{ .Values.glassflowComponents.join.image.pullPolicy | default "IfNotPresent" | quote }}
+  SINK_PULL_POLICY: {{ .Values.glassflowComponents.sink.image.pullPolicy | default "IfNotPresent" | quote }}
+  DEDUP_PULL_POLICY: {{ .Values.glassflowComponents.dedup.image.pullPolicy | default "IfNotPresent" | quote }}
   DEDUP_CPU_REQUEST: {{ .Values.glassflowComponents.dedup.resources.requests.cpu | quote }}
   DEDUP_CPU_LIMIT: {{ .Values.glassflowComponents.dedup.resources.limits.cpu | quote }}
   DEDUP_MEMORY_REQUEST: {{ .Values.glassflowComponents.dedup.resources.requests.memory | quote }}

--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -67,6 +67,7 @@ glassflowComponents:
     image:
       repository: glassflow-etl-ingestor
       tag: v2.4.0
+      pullPolicy: IfNotPresent
     logLevel: "INFO"
     resources:
       requests:
@@ -81,6 +82,7 @@ glassflowComponents:
     image:
       repository: glassflow-etl-join
       tag: v2.4.0
+      pullPolicy: IfNotPresent
     logLevel: "INFO"
     resources:
       requests:
@@ -95,6 +97,7 @@ glassflowComponents:
     image:
       repository: glassflow-etl-sink
       tag: v2.4.0
+      pullPolicy: IfNotPresent
     logLevel: "INFO"
     resources:
       requests:
@@ -109,6 +112,7 @@ glassflowComponents:
     image:
       repository: glassflow-etl-dedup
       tag: v2.4.0
+      pullPolicy: IfNotPresent
     logLevel: "INFO"
     resources:
       requests:


### PR DESCRIPTION
Chart changes linked to #88 

Useful when we make change in a component and user doesn't want to upgrade the entire chart.
Also helps with internal testing of PR  images.