### PR TITLE
ETL-626: visibility of pipeline configuration in kubernetes

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -39,7 +39,11 @@ type PipelineSpec struct {
 	Ingestor Sources `json:"sources"`
 	Join     Join    `json:"join"`
 	Sink     Sink    `json:"sink"`
-	Config   string  `json:"config"`
+	// Config will be deprecated. Initial Pipeline configuration is now read from a Kubernetes Secret
+	// in the glassflow namespace (pipeline-config-{pipeline_id}). This field is kept for
+	// backward compatibility and will be used as a fallback if the secret is not found.
+	// +optional
+	Config string `json:"config,omitempty"`
 }
 
 type Sources struct {

--- a/charts/glassflow-operator/templates/pipeline-crd.yaml
+++ b/charts/glassflow-operator/templates/pipeline-crd.yaml
@@ -154,7 +154,6 @@ spec:
                 - type
                 type: object
             required:
-            - config
             - dlq
             - join
             - pipeline_id

--- a/charts/glassflow-operator/templates/pipeline-crd.yaml
+++ b/charts/glassflow-operator/templates/pipeline-crd.yaml
@@ -39,6 +39,10 @@ spec:
             description: PipelineSpec defines the desired state of Pipeline.
             properties:
               config:
+                description: |-
+                  Config will be deprecated. Initial Pipeline configuration is now read from a Kubernetes Secret
+                  in the glassflow namespace (pipeline-config-{pipeline_id}). This field is kept for
+                  backward compatibility and will be used as a fallback if the secret is not found.
                 type: string
               dlq:
                 type: string

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -494,6 +494,7 @@ func main() {
 		DedupImageTag:               dedupImageTag,
 		PipelinesNamespaceAuto:      pipelinesNamespaceAuto,
 		PipelinesNamespaceName:      pipelinesNamespaceName,
+		GlassflowNamespace:          podNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Pipeline")
 		os.Exit(1)

--- a/config/crd/bases/etl.glassflow.io_pipelines.yaml
+++ b/config/crd/bases/etl.glassflow.io_pipelines.yaml
@@ -40,6 +40,10 @@ spec:
             description: PipelineSpec defines the desired state of Pipeline.
             properties:
               config:
+                description: |-
+                  Config is deprecated. Pipeline configuration is now stored in a Kubernetes Secret
+                  in the glassflow namespace (pipeline-config-{pipeline_id}). This field is kept for
+                  backward compatibility and will be used as a fallback if the secret is not found.
                 type: string
               dlq:
                 type: string
@@ -151,7 +155,6 @@ spec:
                 - type
                 type: object
             required:
-            - config
             - dlq
             - join
             - pipeline_id

--- a/config/crd/bases/etl.glassflow.io_pipelines.yaml
+++ b/config/crd/bases/etl.glassflow.io_pipelines.yaml
@@ -41,7 +41,7 @@ spec:
             properties:
               config:
                 description: |-
-                  Config is deprecated. Pipeline configuration is now stored in a Kubernetes Secret
+                  Config will be deprecated. Initial Pipeline configuration is now read from a Kubernetes Secret
                   in the glassflow namespace (pipeline-config-{pipeline_id}). This field is kept for
                   backward compatibility and will be used as a fallback if the secret is not found.
                 type: string

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -299,86 +299,10 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("create secret for pipeline config %s: %w", p.Spec.ID, err)
 	}
 
-	namespace := r.getTargetNamespace(p)
-
-	// Step 1: Create Sink deployment
-	ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "sink"))
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("check sink deployment: %w", err)
-	}
-	if !ready {
-		// Check for timeout before requeuing
-		timedOut, _ := r.checkOperationTimeout(log, &p)
-		if timedOut {
-			return r.handleOperationTimeout(ctx, log, &p, "create")
-		}
-
-		log.Info("creating sink deployment", "namespace", namespace)
-		err = r.createSink(ctx, ns, labels, secret, p)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("create sink deployment: %w", err)
-		}
-		// Requeue to wait for deployment to be ready
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-	} else {
-		log.Info("sink deployment is ready", "namespace", namespace)
-	}
-
-	// Step 2: Create Join deployment (if enabled)
-	if p.Spec.Join.Enabled {
-		ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "join"))
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check join deployment: %w", err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, "create")
-			}
-
-			log.Info("creating join deployment", "namespace", namespace)
-			err := r.createJoin(ctx, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create join deployment: %w", err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		} else {
-			log.Info("join deployment is already created", "namespace", namespace)
-		}
-	}
-
-	// Step 3: Create Dedup StatefulSets (if any stream has dedup enabled)
-	result, err := r.ensureDedupStatefulSetsReady(ctx, log, p, ns, labels, secret, "create")
+	// Ensure all deployments are ready
+	result, err := r.ensureAllDeploymentsReady(ctx, log, &p, ns, labels, secret, constants.OperationCreate)
 	if err != nil || result.Requeue {
 		return result, err
-	}
-
-	// Step 4: Create Ingestor deployments
-	for i := range p.Spec.Ingestor.Streams {
-		deploymentName := r.getResourceName(p, fmt.Sprintf("ingestor-%d", i))
-		ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, "create")
-			}
-
-			log.Info("creating ingestor deployment", "deployment", deploymentName, "namespace", namespace)
-			err = r.createIngestors(ctx, log, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create ingestor deployment %s: %w", deploymentName, err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		} else {
-			log.Info("ingestor deployment is already created", "namespace", namespace)
-		}
 	}
 
 	// All deployments are ready, update status to Running
@@ -706,88 +630,14 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 
 	err = r.createNATSStreams(ctx, p)
 	if err != nil {
-		r.recordReconcileError(ctx, "edit", pipelineID, err)
+		r.recordReconcileError(ctx, "resume", pipelineID, err)
 		return ctrl.Result{}, fmt.Errorf("setup streams: %w", err)
 	}
 
-	// Step 1: Create Sink deployment
-	ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "sink"))
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("check sink deployment: %w", err)
-	}
-	if !ready {
-		// Check for timeout before requeuing
-		timedOut, _ := r.checkOperationTimeout(log, &p)
-		if timedOut {
-			return r.handleOperationTimeout(ctx, log, &p, constants.OperationResume)
-		}
-
-		log.Info("creating sink deployment", "namespace", namespace)
-		err = r.createSink(ctx, ns, labels, secret, p)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("create sink deployment: %w", err)
-		}
-		// Requeue to wait for deployment to be ready
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-	} else {
-		log.Info("sink deployment is already created", "namespace", namespace)
-	}
-
-	// Step 2: Create Join deployment (if enabled)
-	if p.Spec.Join.Enabled {
-		ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "join"))
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check join deployment: %w", err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, constants.OperationResume)
-			}
-
-			log.Info("creating join deployment", "namespace", namespace)
-			err = r.createJoin(ctx, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create join deployment: %w", err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		} else {
-			log.Info("join deployment is already created", "namespace", namespace)
-		}
-	}
-
-	// Step 3: Create Dedup StatefulSets (if any stream has dedup enabled)
-	result, err := r.ensureDedupStatefulSetsReady(ctx, log, p, ns, labels, secret, constants.OperationResume)
+	// Ensure all deployments are ready
+	result, err := r.ensureAllDeploymentsReady(ctx, log, &p, ns, labels, secret, constants.OperationResume)
 	if err != nil || result.Requeue {
 		return result, err
-	}
-
-	// Step 4: Create Ingestor deployments
-	for i := range p.Spec.Ingestor.Streams {
-		deploymentName := r.getResourceName(p, fmt.Sprintf("ingestor-%d", i))
-		ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, constants.OperationResume)
-			}
-
-			log.Info("creating ingestor deployment", "deployment", deploymentName, "namespace", namespace)
-			err = r.createIngestors(ctx, log, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create ingestor deployment %s: %w", deploymentName, err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		} else {
-			log.Info("ingestor deployment is already created", "namespace", namespace)
-		}
 	}
 
 	// All deployments are ready, update status to Running
@@ -955,78 +805,10 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("setup streams: %w", err)
 	}
 
-	// Step 1: Create Sink deployment
-	ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "sink"))
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("check sink deployment: %w", err)
-	}
-	if !ready {
-		// Check for timeout before requeuing
-		timedOut, _ := r.checkOperationTimeout(log, &p)
-		if timedOut {
-			return r.handleOperationTimeout(ctx, log, &p, constants.OperationEdit)
-		}
-
-		log.Info("creating sink deployment", "namespace", namespace)
-		err = r.createSink(ctx, ns, labels, secret, p)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("create sink deployment: %w", err)
-		}
-		// Requeue to wait for deployment to be ready
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-	}
-
-	// Step 2: Create Join deployment (if enabled)
-	if p.Spec.Join.Enabled {
-		ready, err := r.isDeploymentReady(ctx, namespace, r.getResourceName(p, "join"))
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check join deployment: %w", err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, constants.OperationEdit)
-			}
-
-			log.Info("creating join deployment", "namespace", namespace)
-			err = r.createJoin(ctx, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create join deployment: %w", err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		}
-	}
-
-	// Step 3: Create Dedup StatefulSets (if any stream has dedup enabled)
-	result, err := r.ensureDedupStatefulSetsReady(ctx, log, p, ns, labels, secret, constants.OperationEdit)
+	// Ensure all deployments are ready
+	result, err := r.ensureAllDeploymentsReady(ctx, log, &p, ns, labels, secret, constants.OperationEdit)
 	if err != nil || result.Requeue {
 		return result, err
-	}
-
-	// Step 4: Create Ingestor deployments
-	for i := range p.Spec.Ingestor.Streams {
-		deploymentName := r.getResourceName(p, fmt.Sprintf("ingestor-%d", i))
-		ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
-		}
-		if !ready {
-			// Check for timeout before requeuing
-			timedOut, _ := r.checkOperationTimeout(log, &p)
-			if timedOut {
-				return r.handleOperationTimeout(ctx, log, &p, constants.OperationEdit)
-			}
-
-			log.Info("creating ingestor deployment", "deployment", deploymentName, "namespace", namespace)
-			err = r.createIngestors(ctx, log, ns, labels, secret, p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("create ingestor deployment %s: %w", deploymentName, err)
-			}
-			// Requeue to wait for deployment to be ready
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-		}
 	}
 
 	// All deployments are ready, update status to Running
@@ -1122,6 +904,108 @@ func (r *PipelineReconciler) ensureDedupStatefulSetsReady(
 		} else {
 			log.Info("dedup statefulsets are ready", "namespace", namespace)
 		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ensureDeploymentReady checks if a deployment is ready, creates it if not, and handles timeouts.
+func (r *PipelineReconciler) ensureDeploymentReady(
+	ctx context.Context,
+	log logr.Logger,
+	p *etlv1alpha1.Pipeline,
+	namespace,
+	deploymentName,
+	operationName string,
+	createFn func(context.Context, v1.Namespace, map[string]string, v1.Secret, etlv1alpha1.Pipeline) error,
+	ns v1.Namespace,
+	labels map[string]string,
+	secret v1.Secret,
+) (bool, error) {
+	ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
+	if err != nil {
+		return false, fmt.Errorf("check %s deployment: %w", deploymentName, err)
+	}
+	if ready {
+		log.Info(fmt.Sprintf("%s deployment is already ready", deploymentName), "namespace", namespace)
+		return false, nil
+	}
+
+	// Check for timeout before creating
+	timedOut, _ := r.checkOperationTimeout(log, p)
+	if timedOut {
+		_, err := r.handleOperationTimeout(ctx, log, p, operationName)
+		return false, err
+	}
+
+	log.Info(fmt.Sprintf("creating %s deployment", deploymentName), "namespace", namespace)
+	err = createFn(ctx, ns, labels, secret, *p)
+	if err != nil {
+		return false, fmt.Errorf("create %s deployment: %w", deploymentName, err)
+	}
+	return true, nil
+}
+
+// ensureAllDeploymentsReady ensures all required deployments (sink, join, dedup, ingestor) are ready.
+func (r *PipelineReconciler) ensureAllDeploymentsReady(
+	ctx context.Context,
+	log logr.Logger,
+	p *etlv1alpha1.Pipeline,
+	ns v1.Namespace,
+	labels map[string]string,
+	secret v1.Secret,
+	operationName string,
+) (ctrl.Result, error) {
+	namespace := r.getTargetNamespace(*p)
+
+	// Step 1: Ensure Sink deployment is ready
+	requeue, err := r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, "sink"), operationName, r.createSink, ns, labels, secret)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if requeue {
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
+	}
+
+	// Step 2: Ensure Join deployment is ready (if enabled)
+	if p.Spec.Join.Enabled {
+		requeue, err := r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, "join"), operationName, r.createJoin, ns, labels, secret)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if requeue {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
+		}
+	}
+
+	// Step 3: Ensure Dedup StatefulSets are ready
+	result, err := r.ensureDedupStatefulSetsReady(ctx, log, *p, ns, labels, secret, operationName)
+	if err != nil || result.Requeue {
+		return result, err
+	}
+
+	// Step 4: Ensure Ingestor deployments are ready
+	for i := range p.Spec.Ingestor.Streams {
+		deploymentName := r.getResourceName(*p, fmt.Sprintf("ingestor-%d", i))
+		ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
+		}
+		if !ready {
+			// Check for timeout before requeuing
+			timedOut, _ := r.checkOperationTimeout(log, p)
+			if timedOut {
+				return r.handleOperationTimeout(ctx, log, p, operationName)
+			}
+
+			log.Info("creating ingestor deployment", "deployment", deploymentName, "namespace", namespace)
+			err = r.createIngestors(ctx, log, ns, labels, secret, *p)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("create ingestor deployment %s: %w", deploymentName, err)
+			}
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
+		}
+		log.Info("ingestor deployment is already ready", "deployment", deploymentName, "namespace", namespace)
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
Issue: We use pipeline CRD.config to share the pipeline JSON but this exposes credentials
We could encrypt them but the components will need to decrypt them, and components need the encryption key.

Solution:
1. API creates a secret in it's own namespace, with the config, then the CRD.
2. Operator reads it and creates the secret in pipeline namespace.
3. Admin can then apply RBAC to prevent reading secrets within the pipeline namespace.
4. Pipeline JSON is only present in secret and DB 

[Linked CH-ETL PR](https://github.com/glassflow/clickhouse-etl/pull/451)