### PR TITLE
fix: secret cleanup when all pipelines deployed in same namespace

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -33,3 +33,12 @@ const (
 	OperationTerminate     = "terminate"
 	OperationHelmUninstall = "helm-uninstall"
 )
+
+// resource name constants (used for prefix / suffix when naming resources)
+const (
+	SecretSuffix      = "secret"
+	DedupComponent    = "dedup"
+	SinkComponent     = "sink"
+	IngestorComponent = "ingestor"
+	JoinComponent     = "join"
+)

--- a/internal/controller/components.go
+++ b/internal/controller/components.go
@@ -43,7 +43,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 
 	// Step 1: Stop Ingestor deployments
 	for i := range p.Spec.Ingestor.Streams {
-		deploymentName := r.getResourceName(*p, fmt.Sprintf("ingestor-%d", i))
+		deploymentName := r.getResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 		deleted, err := r.isDeploymentAbsent(ctx, namespace, deploymentName)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
@@ -92,7 +92,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 		// Check for pending messages first
 		err := r.checkDedupPendingMessages(ctx, *p, i)
 		if err != nil {
-			log.Info("dedup has pending messages, requeuing", "dedup", dedupName, "error", err.Error())
+			log.Info("dedup has pending messages, requeuing", constants.DedupComponent, dedupName, "error", err.Error())
 			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 		}
 
@@ -137,7 +137,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 		}
 
-		deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(*p, "join"))
+		deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(*p, constants.JoinComponent))
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check join deployment: %w", err)
 		}
@@ -150,7 +150,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 
 			log.Info("deleting join deployment", "namespace", namespace)
 			var deployment appsv1.Deployment
-			err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(*p, "join")}, &deployment)
+			err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(*p, constants.JoinComponent)}, &deployment)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					return ctrl.Result{}, fmt.Errorf("get join deployment: %w", err)
@@ -184,7 +184,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 	}
 
-	deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(*p, "sink"))
+	deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(*p, constants.SinkComponent))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("check sink deployment: %w", err)
 	}
@@ -197,7 +197,7 @@ func (r *PipelineReconciler) stopPipelineComponents(ctx context.Context, log log
 
 		log.Info("deleting sink deployment", "namespace", namespace)
 		var deployment appsv1.Deployment
-		err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(*p, "sink")}, &deployment)
+		err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(*p, constants.SinkComponent)}, &deployment)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("get sink deployment: %w", err)
@@ -224,7 +224,7 @@ func (r *PipelineReconciler) terminatePipelineComponents(ctx context.Context, lo
 
 	// Step 1: Stop Ingestor deployments
 	for i := range p.Spec.Ingestor.Streams {
-		deploymentName := r.getResourceName(p, fmt.Sprintf("ingestor-%d", i))
+		deploymentName := r.getResourceName(p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 		deleted, err := r.isDeploymentAbsent(ctx, namespace, deploymentName)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check ingestor deployment %s: %w", deploymentName, err)
@@ -283,14 +283,14 @@ func (r *PipelineReconciler) terminatePipelineComponents(ctx context.Context, lo
 
 	// Step 3: Check join and stop Join deployment (if enabled)
 	if p.Spec.Join.Enabled {
-		deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(p, "join"))
+		deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(p, constants.JoinComponent))
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check join deployment: %w", err)
 		}
 		if !deleted {
 			log.Info("deleting join deployment", "namespace", namespace)
 			var deployment appsv1.Deployment
-			err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, "join")}, &deployment)
+			err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, constants.JoinComponent)}, &deployment)
 			if err != nil {
 				if !apierrors.IsNotFound(err) {
 					return ctrl.Result{}, fmt.Errorf("get join deployment: %w", err)
@@ -309,14 +309,14 @@ func (r *PipelineReconciler) terminatePipelineComponents(ctx context.Context, lo
 	}
 
 	// Step 3: Check sink and stop Sink deployment
-	deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(p, "sink"))
+	deleted, err := r.isDeploymentAbsent(ctx, namespace, r.getResourceName(p, constants.SinkComponent))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("check sink deployment: %w", err)
 	}
 	if !deleted {
 		log.Info("deleting sink deployment", "namespace", namespace)
 		var deployment appsv1.Deployment
-		err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, "sink")}, &deployment)
+		err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, constants.SinkComponent)}, &deployment)
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, fmt.Errorf("get sink deployment: %w", err)
@@ -342,7 +342,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 	ing := p.Spec.Ingestor
 
 	for i, t := range ing.Streams {
-		resourceRef := r.getResourceName(p, fmt.Sprintf("ingestor-%d", i))
+		resourceRef := r.getResourceName(p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 
 		ingestorLabels := r.getKafkaIngestorLabels(t.TopicName)
 		maps.Copy(ingestorLabels, labels)
@@ -367,7 +367,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 				{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 				{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
 				{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: r.ObservabilityOTelEndpoint},
-				{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: "ingestor"},
+				{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: constants.IngestorComponent},
 				{Name: "GLASSFLOW_OTEL_SERVICE_VERSION", Value: r.IngestorImageTag},
 				{Name: "GLASSFLOW_OTEL_SERVICE_NAMESPACE", Value: r.getTargetNamespace(p)},
 				{Name: "GLASSFLOW_OTEL_PIPELINE_ID", Value: p.Spec.ID},
@@ -409,7 +409,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 
 // createJoin creates a join deployment for the pipeline
 func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, labels map[string]string, secret v1.Secret, p etlv1alpha1.Pipeline) error {
-	resourceRef := r.getResourceName(p, "join")
+	resourceRef := r.getResourceName(p, constants.JoinComponent)
 
 	joinLabels := r.getJoinLabels()
 
@@ -434,7 +434,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 			{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
 			{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: r.ObservabilityOTelEndpoint},
-			{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: "join"},
+			{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: constants.JoinComponent},
 			{Name: "GLASSFLOW_OTEL_SERVICE_VERSION", Value: r.JoinImageTag},
 			{Name: "GLASSFLOW_OTEL_SERVICE_NAMESPACE", Value: r.getTargetNamespace(p)},
 			{Name: "GLASSFLOW_OTEL_PIPELINE_ID", Value: p.Spec.ID},
@@ -474,7 +474,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 
 // createSink creates a sink deployment for the pipeline
 func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, labels map[string]string, secret v1.Secret, p etlv1alpha1.Pipeline) error {
-	resourceRef := r.getResourceName(p, "sink")
+	resourceRef := r.getResourceName(p, constants.SinkComponent)
 
 	sinkLabels := r.getSinkLabels()
 	maps.Copy(sinkLabels, labels)
@@ -498,7 +498,7 @@ func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 			{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
 			{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: r.ObservabilityOTelEndpoint},
-			{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: "sink"},
+			{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: constants.SinkComponent},
 			{Name: "GLASSFLOW_OTEL_SERVICE_VERSION", Value: r.SinkImageTag},
 			{Name: "GLASSFLOW_OTEL_SERVICE_NAMESPACE", Value: r.getTargetNamespace(p)},
 			{Name: "GLASSFLOW_OTEL_PIPELINE_ID", Value: p.Spec.ID},
@@ -594,7 +594,7 @@ func (r *PipelineReconciler) createDedups(ctx context.Context, _ logr.Logger, ns
 				{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.ObservabilityLogsEnabled},
 				{Name: "GLASSFLOW_OTEL_METRICS_ENABLED", Value: r.ObservabilityMetricsEnabled},
 				{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: r.ObservabilityOTelEndpoint},
-				{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: "dedup"},
+				{Name: "GLASSFLOW_OTEL_SERVICE_NAME", Value: constants.DedupComponent},
 				{Name: "GLASSFLOW_OTEL_SERVICE_VERSION", Value: r.DedupImageTag},
 				{Name: "GLASSFLOW_OTEL_SERVICE_NAMESPACE", Value: r.getTargetNamespace(p)},
 				{Name: "GLASSFLOW_OTEL_PIPELINE_ID", Value: p.Spec.ID},

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -296,7 +296,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 
 	labels := preparePipelineLabels(p)
 
-	secretName := r.getResourceName(p, p.Spec.ID)
+	secretName := r.getResourceName(p, "secret")
 	secret, err := r.createSecret(ctx, types.NamespacedName{Namespace: ns.GetName(), Name: secretName}, labels, p)
 	if err != nil {
 		if errors.Is(err, ErrPipelineConfigSecretNotFound) {
@@ -626,7 +626,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 	}
 
 	// Get secret
-	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, p.Spec.ID)}
+	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, "secret")}
 	var secret v1.Secret
 	err = r.Get(ctx, secretName, &secret)
 	if err != nil {
@@ -782,7 +782,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 
 	// Update the pipeline config secret with new config
 	labels := preparePipelineLabels(p)
-	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, p.Spec.ID)}
+	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, "secret")}
 	_, err := r.updateSecret(ctx, secretName, labels, p)
 	if err != nil {
 		if errors.Is(err, ErrPipelineConfigSecretNotFound) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -410,10 +410,15 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 		log.Info("pipeline is not stopped but attempting to delete", "pipeline_id", p.Spec.ID)
 	}
 
-	// Delete namespace for this pipeline
+	// only if pipelines have individual NS
 	err := r.deleteNamespace(ctx, log, p)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("delete pipeline namespace: %w", err)
+	}
+
+	err = r.deleteSecret(ctx, log, p)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("delete pipeline secret: %w", err)
 	}
 
 	// Clean up NATS streams

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
 	v1 "k8s.io/api/core/v1"
 
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
@@ -28,7 +29,7 @@ import (
 // getKafkaIngestorLabels returns labels for Kafka ingestor components
 func (r *PipelineReconciler) getKafkaIngestorLabels(topic string) map[string]string {
 	labels := map[string]string{
-		"etl.glassflow.io/component": "ingestor",
+		"etl.glassflow.io/component": constants.IngestorComponent,
 		"etl.glassflow.io/topic":     topic,
 	}
 
@@ -38,7 +39,7 @@ func (r *PipelineReconciler) getKafkaIngestorLabels(topic string) map[string]str
 // getJoinLabels returns labels for join components
 func (r *PipelineReconciler) getJoinLabels() map[string]string {
 	labels := map[string]string{
-		"etl.glassflow.io/component": "join",
+		"etl.glassflow.io/component": constants.JoinComponent,
 	}
 
 	return labels
@@ -47,7 +48,7 @@ func (r *PipelineReconciler) getJoinLabels() map[string]string {
 // getSinkLabels returns labels for sink components
 func (r *PipelineReconciler) getSinkLabels() map[string]string {
 	labels := map[string]string{
-		"etl.glassflow.io/component": "sink",
+		"etl.glassflow.io/component": constants.SinkComponent,
 	}
 
 	return labels
@@ -56,7 +57,7 @@ func (r *PipelineReconciler) getSinkLabels() map[string]string {
 // getDedupLabels returns labels for dedup components
 func (r *PipelineReconciler) getDedupLabels(topic string) map[string]string {
 	labels := map[string]string{
-		"etl.glassflow.io/component": "dedup",
+		"etl.glassflow.io/component": constants.DedupComponent,
 		"etl.glassflow.io/topic":     topic,
 	}
 

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -273,7 +274,7 @@ func (r *PipelineReconciler) deleteSecret(ctx context.Context, log logr.Logger, 
 		return nil
 	}
 
-	secretName := types.NamespacedName{Namespace: r.PipelinesNamespaceName, Name: r.getResourceName(p, "secret")}
+	secretName := types.NamespacedName{Namespace: r.PipelinesNamespaceName, Name: r.getResourceName(p, constants.SecretSuffix)}
 	var secret v1.Secret
 	err := r.Get(ctx, secretName, &secret)
 	if err != nil {


### PR DESCRIPTION
Issue: Since namespace cannot be deleted for group namespaces pipelines, secrets were not being cleaned.

Fixes: 
1. Check if group NS and delete secret.
2. Shorten secret name.