### PR TITLE
fix: add validation to disable a usage stats client if necessary

### DIFF
--- a/pkg/usagestats/client.go
+++ b/pkg/usagestats/client.go
@@ -61,6 +61,16 @@ func NewClient(endpoint, username, password, installationID string, enabled bool
 		return &Client{enabled: false}
 	}
 
+	// Validate required fields - if any are missing, disable usage stats gracefully
+	if endpoint == "" || username == "" || password == "" || installationID == "" {
+		log.Info("Usage stats disabled: missing required configuration",
+			"endpoint_empty", endpoint == "",
+			"username_empty", username == "",
+			"password_empty", password == "",
+			"installation_id_empty", installationID == "")
+		return &Client{enabled: false}
+	}
+
 	return &Client{
 		endpoint:       endpoint,
 		username:       username,


### PR DESCRIPTION
Issue: In some infra management tools hooks may not run / disabled. Adding safeguard to disable client if necessary prams are not available.

[Same changes as this PR](https://github.com/glassflow/clickhouse-etl/pull/460)