### PR TITLE
feat: read DB and encryption config from main chart and pass it to operator

### DIFF
--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -221,6 +221,14 @@ spec:
               key: installation_id
               optional: true
         {{- end }}
+        {{- if and .Values.global.encryption.enabled (or .Values.global.encryption.existingSecret.name .Values.global.encryption.createSecret) }}
+        - name: COMPONENT_ENCRYPTION_ENABLED
+          value: "true"
+        - name: COMPONENT_ENCRYPTION_SECRET_NAME
+          value: {{ if .Values.global.encryption.existingSecret.name }}{{ .Values.global.encryption.existingSecret.name | quote }}{{ else }}{{ .Values.global.encryption.secretName | default (printf "%s-encryption-key" .Release.Name) | quote }}{{ end }}
+        - name: COMPONENT_ENCRYPTION_SECRET_KEY
+          value: {{ .Values.global.encryption.existingSecret.key | default "encryption-key" | quote }}
+        {{- end }}
         image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
         livenessProbe:

--- a/charts/glassflow-operator/templates/manager-rbac.yaml
+++ b/charts/glassflow-operator/templates/manager-rbac.yaml
@@ -26,6 +26,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -24,7 +24,7 @@ global:
       # When auto is false, Helm can optionally create the namespace
       create: true
 
-  # PostgreSQL connection URL
+  # PostgreSQL connection URL (same as API; operator passes DSN to pipeline components)
   # Only used when external postgres is used by the user.
   # By default, operator uses postgres deployed by the glassflow-etl chart.
   postgres:
@@ -34,6 +34,15 @@ global:
     secret:
       name: ""
       key: ""
+
+  # Encryption for pipeline components (same as API; when enabled, operator copies secret into pipeline namespaces)
+  encryption:
+    enabled: false
+    existingSecret:
+      name: ""
+      key: "encryption-key"
+    createSecret: false
+    secretName: ""  # Defaults to "{{ .Release.Name }}-encryption-key" if empty
 
 controllerManager:
   manager:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,12 +8,23 @@ rules:
   - ""
   resources:
   - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - apps


### PR DESCRIPTION
Passes DB URL and Encryption secret similar to how main chart passes it to API