### PR TITLE
fix: edit pipeline secret management

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -836,7 +836,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 	// Update the pipeline config secret with new config
 	labels := preparePipelineLabels(p)
 	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, constants.SecretSuffix)}
-	_, err := r.updateSecret(ctx, secretName, labels, p)
+	secret, err := r.updateSecret(ctx, secretName, labels, p)
 	if err != nil {
 		if errors.Is(err, ErrPipelineConfigSecretNotFound) {
 			log.Info("pipeline config secret not found during edit, requeuing to wait for API to create it", "pipeline_id", pipelineID, "error", err)
@@ -863,17 +863,11 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		}
 	}
 
-	// Get namespace and secret for deployment creation
+	// Get namespace for deployment creation
 	var ns v1.Namespace
 	err = r.Get(ctx, types.NamespacedName{Name: namespace}, &ns)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", namespace, err)
-	}
-
-	var secret v1.Secret
-	err = r.Get(ctx, secretName, &secret)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("get secret %s: %w", secretName, err)
 	}
 
 	err = r.createNATSStreams(ctx, p)

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -238,6 +239,12 @@ func (r *PipelineReconciler) updateSecret(ctx context.Context, namespacedName ty
 
 	if pipelineConfig == "" {
 		return zero, fmt.Errorf("pipeline config is empty for pipeline %s, cannot update secret", p.Spec.ID)
+	}
+
+	// avoids redundant churn on requeue if content is unchanged
+	existingData := existingSecret.Data["pipeline.json"]
+	if bytes.Equal(existingData, []byte(pipelineConfig)) {
+		return existingSecret, nil
 	}
 
 	// recreate new secret


### PR DESCRIPTION
After recreating secret for edit pipeline, the secret may not be available immediately, so reuse in memory instead of attempting read immediately