### PR TITLE
ETL-721: feat: update reconcile timeout to 15 minutes

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,7 +20,7 @@ const (
 	PipelineOperationStartTimeAnnotation = "pipeline.etl.glassflow.io/operation-start-time"
 
 	// ReconcileTimeout is the maximum duration a reconcile operation can run before timing out
-	ReconcileTimeout = 5 * time.Minute
+	ReconcileTimeout = 15 * time.Minute
 )
 
 // Pipeline operation type constants


### PR DESCRIPTION
## Temporary fix

1. If component affinity for a node pool is set and the cluster needs to scale up nodes.
2. If pipeline needs to be stopped but there is a lot of data in the stream

5 minutes timeout is too aggressive.

In a separate PR this will be addressed correctly with checking cluster & stream state and waiting accordingly