### PR TITLE
ETL-786: fix: API always creates CRDs in installation NS

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -634,18 +634,12 @@ func main() {
 		usageStatsClient.SendEvent(context.Background(), "ready", "operator", nil)
 	}()
 
-	crdNS := podNamespace
-	// If user chosen namespace
-	if !pipelinesNamespaceAuto {
-		crdNS = pipelinesNamespaceName
-	}
-
 	componentSignalsConsumer := consumers.NewComponentSignalsConsumer(
 		natsClient,
 		logger,
 		mgr.GetClient(),
 		postgresStorage,
-		crdNS,
+		podNamespace,
 	)
 	if err := mgr.Add(componentSignalsConsumer); err != nil {
 		setupLog.Error(err, "unable to add component signals messages consumer to manager")


### PR DESCRIPTION
Issue: the namespace switch is only for where pipelines are created, CRDs currently are always created in installation namespace (k8Namespace ENV var passed to API) hence we don't need this check else operator fails to find the pipeline
In the chart this is always set to GLASSFLOW_K8S_NAMESPACE: "{{ .Release.Namespace }}"


```sh
2026-02-26T15:22:15Z	INFO	stopping pipeline	{"pipeline_id": "pipeline-dedup-sr", "reason": "schema 100025 is incompatible: field created_at from previous schema is missing in the new schema", "text": "schema id 100025 validation failed", "component": "ingestor"}
2026-02-26T15:22:15Z	INFO	stopping k8s pipeline	{"pipeline_id": "pipeline-dedup-sr"}
2026-02-26T15:22:15Z	INFO	pipeline not found, acking message	{"pipeline_id": "pipeline-dedup-sr"}
```