### PR TITLE
fix: multi stream fixes v1

### DIFF
--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -70,7 +70,10 @@ func (r *PipelineReconciler) createPipelineComponents(
 
 	// Step 2: Ensure Join deployment is ready (if enabled)
 	if p.Spec.Join.Enabled {
-		return r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
+		result, errDep := r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
+		if errDep != nil || result.Requeue {
+			return result, err
+		}
 	}
 
 	// Step 3: Ensure Dedup StatefulSets are ready

--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -681,65 +681,6 @@ func (r *PipelineReconciler) ensureDedupStatefulSetsReady(
 	log.Info("waiting for dedup statefulsets to be ready", "namespace", namespace)
 	return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 }
-
-// ensureDeploymentReady checks if a deployment is ready, creates it if not, and handles timeouts.
-func (r *PipelineReconciler) ensureDeploymentReady(
-	ctx context.Context,
-	log logr.Logger,
-	p *etlv1alpha1.Pipeline,
-	namespace,
-	deploymentName string,
-	createFn func(context.Context, v1.Namespace, map[string]string, v1.Secret, etlv1alpha1.Pipeline) error,
-	ns v1.Namespace,
-	labels map[string]string,
-	secret v1.Secret,
-) (ctrl.Result, error) {
-	ready, err := r.isDeploymentReady(ctx, namespace, deploymentName)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("check %s deployment: %w", deploymentName, err)
-	}
-	if ready {
-		log.Info(fmt.Sprintf("%s deployment is already ready", deploymentName), "namespace", namespace)
-		return ctrl.Result{}, nil
-	}
-
-	timedOut, _ := r.checkOperationTimeout(log, p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, p)
-	}
-
-	log.Info(fmt.Sprintf("creating %s deployment", deploymentName), "namespace", namespace)
-	if err = createFn(ctx, ns, labels, secret, *p); err != nil {
-		return ctrl.Result{}, fmt.Errorf("create %s deployment: %w", deploymentName, err)
-	}
-
-	return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
-}
-
-func (r *PipelineReconciler) ensureDeploymentDeleted(
-	ctx context.Context,
-	log logr.Logger,
-	namespace,
-	componentType,
-	deploymentName string,
-) (ctrl.Result, error) {
-	absent, err := r.isDeploymentAbsent(ctx, namespace, deploymentName)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("check %s deployment %s: %w", componentType, deploymentName, err)
-	}
-	if absent {
-		log.Info(componentType+" deployment is already deleted", "deployment", deploymentName, "namespace", namespace)
-		return ctrl.Result{}, nil
-	}
-
-	log.Info("deleting "+componentType+" deployment", "deployment", deploymentName, "namespace", namespace)
-	if err = r.deleteDeploymentByName(ctx, namespace, deploymentName); err != nil {
-		return ctrl.Result{}, fmt.Errorf("delete %s deployment %s: %w", componentType, deploymentName, err)
-	}
-
-	return ctrl.Result{Requeue: true, RequeueAfter: componentDeleteRequeueDelay}, nil
-}
-
 func (r *PipelineReconciler) ensureStatefulSetDeleted(
 	ctx context.Context,
 	log logr.Logger,

--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -72,7 +72,7 @@ func (r *PipelineReconciler) createPipelineComponents(
 	if p.Spec.Join.Enabled {
 		result, errDep := r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
 		if errDep != nil || result.Requeue {
-			return result, err
+			return result, errDep
 		}
 	}
 

--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -68,11 +68,14 @@ func (r *PipelineReconciler) createPipelineComponents(
 		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 	}
 
-	// Step 2: Ensure Join deployment is ready (if enabled)
+	// Step 2: Ensure Join StatefulSet is ready (if enabled)
 	if p.Spec.Join.Enabled {
-		result, errDep := r.ensureDeploymentReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
-		if errDep != nil || result.Requeue {
-			return result, errDep
+		requeue, err = r.ensureStatefulSetReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if requeue {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
 		}
 	}
 
@@ -228,15 +231,21 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 	return nil
 }
 
-// createJoin creates a join deployment for the pipeline
+// createJoin creates a join StatefulSet (and headless Service) for the pipeline.
 func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, labels map[string]string, secret v1.Secret, p etlv1alpha1.Pipeline) error {
+	if len(p.Spec.Ingestor.Streams) < 2 {
+		return fmt.Errorf("join requires at least 2 source streams")
+	}
+
 	resourceRef := r.getResourceName(p, constants.JoinComponent)
+	namespace := ns.GetName()
 
 	joinLabels := r.getJoinLabels()
 
 	maps.Copy(joinLabels, labels)
 
 	cpuReq, cpuLim, memReq, memLim := r.JoinCPURequest, r.JoinCPULimit, r.JoinMemoryRequest, r.JoinMemoryLimit
+	joinReplicas := constants.DefaultMinReplicas
 	if p.Spec.Resources != nil && p.Spec.Resources.Join != nil {
 		comp := p.Spec.Resources.Join
 		if comp.Requests != nil {
@@ -245,9 +254,20 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 		if comp.Limits != nil {
 			cpuLim, memLim = comp.Limits.CPU.String(), comp.Limits.Memory.String()
 		}
+		if comp.Replicas != nil {
+			joinReplicas = int(*comp.Replicas)
+		}
 	}
 
 	natsMaxAge, natsMaxBytes := r.resolveNatsStreamEnvVars(p)
+	leftInputStreamPrefix := getJoinInputStreamName(p, p.Spec.Ingestor.Streams[0])
+	rightInputStreamPrefix := getJoinInputStreamName(p, p.Spec.Ingestor.Streams[1])
+	joinOutputSubjectPrefix := getJoinOutputSubjectPrefix(p.Spec.ID)
+
+	err := r.createHeadlessService(ctx, namespace, resourceRef, joinLabels)
+	if err != nil {
+		return fmt.Errorf("create join headless service: %w", err)
+	}
 
 	joinContainerBuilder := newComponentContainerBuilder().
 		withName(resourceRef).
@@ -258,9 +278,12 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			ReadOnly:  true,
 			MountPath: "/config",
 		}).
-		withEnv(append(append([]v1.EnvVar{
+		withEnv(append(append(append([]v1.EnvVar{
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.ComponentNATSAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
+			{Name: "NATS_LEFT_INPUT_STREAM_PREFIX", Value: leftInputStreamPrefix},
+			{Name: "NATS_RIGHT_INPUT_STREAM_PREFIX", Value: rightInputStreamPrefix},
+			{Name: "NATS_SUBJECT_PREFIX", Value: joinOutputSubjectPrefix},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.JoinLogLevel},
 			{Name: "GLASSFLOW_NATS_MAX_STREAM_AGE", Value: natsMaxAge},
 			{Name: "GLASSFLOW_NATS_MAX_STREAM_BYTES", Value: natsMaxBytes},
@@ -277,16 +300,17 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 					FieldPath: "metadata.name",
 				},
 			}},
-		}, r.getComponentDatabaseEnvVars()...), r.getUsageStatsEnvVars()...)).
+		}, r.getStatefulSetPodIdentityEnvVars()...), r.getComponentDatabaseEnvVars()...), r.getUsageStatsEnvVars()...)).
 		withResources(cpuReq, cpuLim, memReq, memLim)
 	if mount, ok := r.getComponentEncryptionVolumeMount(); ok {
 		joinContainerBuilder = joinContainerBuilder.withVolumeMount(mount)
 	}
 	joinContainer := joinContainerBuilder.build()
 
-	joinDepBuilder := newComponentDeploymentBuilder().
+	stsBuilder := newComponentStatefulSetBuilder().
 		withNamespace(ns).
 		withResourceName(resourceRef).
+		withServiceName(resourceRef).
 		withLabels(joinLabels).
 		withVolume(v1.Volume{
 			Name: "config",
@@ -298,18 +322,16 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			},
 		}).
 		withContainer(*joinContainer).
+		withReplicas(joinReplicas).
 		withAffinity(r.JoinAffinity)
-	if p.Spec.Resources != nil && p.Spec.Resources.Join != nil && p.Spec.Resources.Join.Replicas != nil {
-		joinDepBuilder = joinDepBuilder.withReplicas(int(*p.Spec.Resources.Join.Replicas))
-	}
 	if vol, ok := r.getComponentEncryptionVolume(); ok {
-		joinDepBuilder = joinDepBuilder.withVolume(vol)
+		stsBuilder = stsBuilder.withVolume(vol)
 	}
-	deployment := joinDepBuilder.build()
+	statefulSet := stsBuilder.build()
 
-	err := r.createDeployment(ctx, deployment)
+	err = r.createStatefulSet(ctx, statefulSet)
 	if err != nil {
-		return fmt.Errorf("create join deployment: %w", err)
+		return fmt.Errorf("create join statefulset: %w", err)
 	}
 
 	return nil
@@ -863,8 +885,8 @@ func (r *PipelineReconciler) reconcileJoinTeardown(
 		return result, err
 	}
 
-	deploymentName := r.getResourceName(*p, constants.JoinComponent)
-	return r.ensureDeploymentDeleted(ctx, log, namespace, constants.JoinComponent, deploymentName)
+	statefulSetName := r.getResourceName(*p, constants.JoinComponent)
+	return r.ensureStatefulSetDeleted(ctx, log, namespace, constants.JoinComponent, statefulSetName)
 }
 
 func (r *PipelineReconciler) reconcileSinkTeardown(

--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -781,7 +781,7 @@ func (r *PipelineReconciler) reconcileIngestorTeardown(
 		}
 
 		deploymentName := r.getResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
-		result, err = r.ensureDeploymentDeleted(ctx, log, namespace, "ingestor", deploymentName)
+		result, err = r.ensureStatefulSetDeleted(ctx, log, namespace, "ingestor", deploymentName)
 		if err != nil || result.Requeue {
 			return result, err
 		}
@@ -893,7 +893,7 @@ func (r *PipelineReconciler) reconcileSinkTeardown(
 	}
 
 	deploymentName := r.getResourceName(*p, constants.SinkComponent)
-	return r.ensureDeploymentDeleted(ctx, log, namespace, constants.SinkComponent, deploymentName)
+	return r.ensureStatefulSetDeleted(ctx, log, namespace, constants.SinkComponent, deploymentName)
 }
 
 func (r *PipelineReconciler) checkTeardownTimeout(

--- a/internal/controller/deployment.go
+++ b/internal/controller/deployment.go
@@ -130,12 +130,6 @@ type componentDeployment struct {
 	dep *appsv1.Deployment
 }
 
-func newComponentDeploymentBuilder() *componentDeployment {
-	return &componentDeployment{
-		dep: &appsv1.Deployment{},
-	}
-}
-
 var _ deploymentBuilder = (*componentDeployment)(nil)
 
 // withNamespace implements deploymentBuilder.

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -120,20 +120,6 @@ func (r *PipelineReconciler) deleteNamespace(ctx context.Context, log logr.Logge
 	return nil
 }
 
-// createDeployment creates a deployment
-func (r *PipelineReconciler) createDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
-	err := r.Create(ctx, deployment, &client.CreateOptions{})
-	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-
-		return fmt.Errorf("create deployment: %w", err)
-	}
-
-	return nil
-}
-
 // getPipelineConfigFromSecret reads the pipeline configuration from the secret in glassflow namespace
 func (r *PipelineReconciler) getPipelineConfigFromSecret(ctx context.Context, pipelineID string) (string, error) {
 	secretName := fmt.Sprintf("pipeline-config-%s", pipelineID)
@@ -370,59 +356,6 @@ func (r *PipelineReconciler) ensureComponentSecretsInPipelineNamespace(ctx conte
 	}
 
 	return nil
-}
-
-// isDeploymentAbsent checks if a deployment is fully deleted
-func (r *PipelineReconciler) isDeploymentAbsent(ctx context.Context, namespace, name string) (bool, error) {
-	var deployment appsv1.Deployment
-	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, fmt.Errorf("get deployment %s: %w", name, err)
-	}
-	return false, nil
-}
-
-// isDeploymentReady checks if a deployment is ready
-func (r *PipelineReconciler) isDeploymentReady(ctx context.Context, namespace, name string) (bool, error) {
-	var deployment appsv1.Deployment
-	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deployment)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, fmt.Errorf("get deployment %s: %w", name, err)
-	}
-
-	// Check if deployment is ready
-	if deployment.Status.ReadyReplicas == deployment.Status.Replicas && deployment.Status.Replicas > 0 {
-		return true, nil
-	}
-	return false, nil
-}
-
-// deleteDeployment safely deletes a deployment, handling NotFound errors gracefully
-func (r *PipelineReconciler) deleteDeployment(ctx context.Context, deployment *appsv1.Deployment) error {
-	err := r.Delete(ctx, deployment, &client.DeleteOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil // Already deleted, that's fine
-		}
-		return fmt.Errorf("delete deployment: %w", err)
-	}
-	return nil
-}
-
-// deleteDeploymentByName safely deletes a deployment by name.
-func (r *PipelineReconciler) deleteDeploymentByName(ctx context.Context, namespace, name string) error {
-	return r.deleteDeployment(ctx, &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	})
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -91,7 +91,7 @@ func (r *PipelineReconciler) checkSinkPendingMessages(ctx context.Context, p etl
 		streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
 		for n := 0; n < sinkReplicas; n++ {
 			streamName := streamNamePrefix + "_" + strconv.Itoa(n)
-			consumerName := baseConsumerName + "_" + strconv.Itoa(n)
+			consumerName := baseConsumerName
 			if err := r.checkConsumerPendingMessages(ctx, streamName, consumerName); err != nil {
 				return err
 			}
@@ -119,7 +119,7 @@ func (r *PipelineReconciler) checkDedupPendingMessages(ctx context.Context, p et
 		streamNamePrefix := getDedupInputStreamPrefix(p.Spec.ID, stream.TopicName)
 		for d := 0; d < dedupReplicas; d++ {
 			streamName := streamNamePrefix + "_" + strconv.Itoa(d)
-			consumerName := baseConsumerName + "_" + strconv.Itoa(d)
+			consumerName := baseConsumerName
 			if err := r.checkConsumerPendingMessages(ctx, streamName, consumerName); err != nil {
 				return err
 			}

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -146,85 +146,18 @@ func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha
 		m.RecordNATSOperation(ctx, "create_dlq_stream", "success", p.Spec.ID)
 	})
 
-	// create source streams:
-	useNStreams := useNStreamSinkPath(p)
-	useDedupStreams := useDedupNStreamPath(p)
-	for streamIndex, s := range p.Spec.Ingestor.Streams {
-		if useNStreams {
-			subjectPrefix := getIngestorOutputSubjectPrefix(p.Spec.ID, s.TopicName)
-			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
-			ingestorReplicas := getIngestorReplicas(p, streamIndex)
-			sinkReplicas := getSinkReplicas(p)
-			for n := 0; n < sinkReplicas; n++ {
-				streamName := streamNamePrefix + "_" + strconv.Itoa(n)
-				subjects := getSubjectsForStreamIndex(subjectPrefix, ingestorReplicas, sinkReplicas, n)
-				if len(subjects) == 0 {
-					continue
-				}
-				err := r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
-				if err != nil {
-					return fmt.Errorf("create stream %s: %w", streamName, err)
-				}
-			}
-			break // only one topic in single-topic no-join no-dedup path
-		} else if useDedupStreams {
-			// Dedup path: do not create s.OutputStream or s.Deduplication.OutputStream.
-			// Create sinkReplicas sink streams (sink reads from dedup output).
-			dedupReplicas := getDedupReplicas(p)
-			sinkReplicas := getSinkReplicas(p)
-			dedupOutputSubjectPrefix := getDedupOutputSubjectPrefix(p.Spec.ID, s.TopicName)
-			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
-			for n := 0; n < sinkReplicas; n++ {
-				streamName := streamNamePrefix + "_" + strconv.Itoa(n)
-				subjects := getSubjectsForStreamIndex(dedupOutputSubjectPrefix, dedupReplicas, sinkReplicas, n)
-				if len(subjects) == 0 {
-					continue
-				}
-				err := r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
-				if err != nil {
-					return fmt.Errorf("create stream %s: %w", streamName, err)
-				}
-			}
-			// Create dedupReplicas dedup input streams (dedup reads from ingestor output).
-			ingestorSubjectPrefix := getIngestorOutputSubjectPrefix(p.Spec.ID, s.TopicName)
-			dedupInputStreamPrefix := getDedupInputStreamPrefix(p.Spec.ID, s.TopicName)
-			ingestorReplicas := getIngestorReplicas(p, streamIndex)
-			for d := 0; d < dedupReplicas; d++ {
-				streamName := dedupInputStreamPrefix + "_" + strconv.Itoa(d)
-				subjects := getSubjectsForStreamIndex(ingestorSubjectPrefix, ingestorReplicas, dedupReplicas, d)
-				if len(subjects) == 0 {
-					continue
-				}
-				err := r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
-				if err != nil {
-					return fmt.Errorf("create stream %s: %w", streamName, err)
-				}
-			}
-			break // only one topic in single-topic dedup n-stream path
-		} else {
-			streamName := getIngestorOutputSubjectPrefix(p.Spec.ID, s.TopicName)
-			err := r.NATSClient.CreateOrUpdateStream(ctx, streamName, 0)
-			if err != nil {
-				return fmt.Errorf("create stream %s: %w", streamName, err)
-			}
-		}
-
-		// Create dedup output stream if dedup service is enabled (legacy path: not useDedupNStreamPath)
-		if s.Deduplication != nil && s.Deduplication.Enabled {
-			dedupOutputStreamName := getDedupOutputSubjectPrefix(p.Spec.ID, s.TopicName)
-			err := r.NATSClient.CreateOrUpdateStream(ctx, dedupOutputStreamName, 0)
-			if err != nil {
-				return fmt.Errorf("create dedup output stream %s: %w", dedupOutputStreamName, err)
-			}
-		}
-	}
-
 	// create join stream
 	if p.Spec.Join.Enabled {
-		joinOutputStreamName := getJoinOutputStreamName(p.Spec.ID)
-		err := r.NATSClient.CreateOrUpdateStream(ctx, joinOutputStreamName, 0)
+
+		subjectPrefix := getJoinOutputSubjectPrefix(p.Spec.ID)
+		// create sink input stream (join output stream)
+		streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
+		streamName := streamNamePrefix + "_0"
+		subjects := getSubjectsForStreamIndex(subjectPrefix, 1, 1, 0)
+
+		err = r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
 		if err != nil {
-			return fmt.Errorf("create stream %s: %w", joinOutputStreamName, err)
+			return fmt.Errorf("create stream %s: %w", streamName, err)
 		}
 
 		// create join KV stores for each source stream
@@ -240,9 +173,60 @@ func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha
 
 			kvStreamName := getJoinInputStreamName(p, stream)
 
-			err := r.NATSClient.CreateOrUpdateJoinKeyValueStore(ctx, kvStreamName, ttl)
+			err = r.NATSClient.CreateOrUpdateJoinKeyValueStore(ctx, kvStreamName, ttl)
 			if err != nil {
 				return fmt.Errorf("create join KV store %s: %w", kvStreamName, err)
+			}
+
+			subjectPrefix = getIngestorOutputSubjectPrefix(p.Spec.ID, stream.TopicName)
+			subjects = getSubjectsForStreamIndex(subjectPrefix, 1, 1, 0)
+
+			err = r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, kvStreamName, subjects)
+			if err != nil {
+				return fmt.Errorf("create stream %s: %w", kvStreamName, err)
+			}
+		}
+	} else {
+		source := p.Spec.Ingestor.Streams[0]
+		var subjectPrefix string
+		var subjectCount int
+		if isDedupEnabled(p) {
+			// create dedup input / ingestor output streams
+			ingestorSubjectPrefix := getIngestorOutputSubjectPrefix(p.Spec.ID, source.TopicName)
+			dedupInputStreamPrefix := getDedupInputStreamPrefix(p.Spec.ID, source.TopicName)
+			ingestorReplicas := getIngestorReplicas(p, 0)
+			dedupReplicas := getDedupReplicas(p)
+			for d := 0; d < dedupReplicas; d++ {
+				streamName := dedupInputStreamPrefix + "_" + strconv.Itoa(d)
+				subjects := getSubjectsForStreamIndex(ingestorSubjectPrefix, ingestorReplicas, dedupReplicas, d)
+				if len(subjects) == 0 {
+					continue
+				}
+				err := r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
+				if err != nil {
+					return fmt.Errorf("create stream %s: %w", streamName, err)
+				}
+			}
+
+			subjectPrefix = getDedupOutputSubjectPrefix(p.Spec.ID, source.TopicName)
+			subjectCount = getDedupReplicas(p)
+		} else {
+			subjectPrefix = getIngestorOutputSubjectPrefix(p.Spec.ID, source.TopicName)
+			subjectCount = getIngestorReplicas(p, 0)
+		}
+
+		// create sink input stream (ingestor/dedup output stream)
+		sinkReplicas := getSinkReplicas(p)
+		for n := 0; n < sinkReplicas; n++ {
+			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
+			streamName := streamNamePrefix + "_" + strconv.Itoa(n)
+			subjects := getSubjectsForStreamIndex(subjectPrefix, subjectCount, sinkReplicas, n)
+			if len(subjects) == 0 {
+				continue
+			}
+			err := r.NATSClient.CreateOrUpdateStreamWithSubjects(ctx, streamName, subjects)
+			if err != nil {
+				return fmt.Errorf("create stream %s: %w", streamName, err)
 			}
 		}
 	}
@@ -275,126 +259,58 @@ func (r *PipelineReconciler) cleanupNATSPipelineResources(ctx context.Context, l
 	})
 	log.Info("NATS DLQ stream deleted successfully", "stream", dlqStreamName)
 
-	// delete Ingestor Streams
-	// single-topic no-join no-dedup: delete sinkReplicas sink-input streams
-	// single-topic with dedup: delete sinkReplicas sink + dedupReplicas dedup input streams
-	// otherwise: delete per-topic output stream and optional dedup output
-	useNStreams := useNStreamSinkPath(p)
-	useDedupStreams := useDedupNStreamPath(p)
-	for _, stream := range p.Spec.Ingestor.Streams {
-		if useNStreams {
-			sinkReplicas := getSinkReplicas(p)
-			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
-			for n := 0; n < sinkReplicas; n++ {
-				streamName := streamNamePrefix + "_" + strconv.Itoa(n)
-				log.Info("deleting NATS sink input stream", "stream", streamName)
-				err := r.deleteNATSStream(ctx, log, streamName)
-				if err != nil {
-					r.recordMetricsIfEnabled(func(m *observability.Meter) {
-						m.RecordNATSOperation(ctx, "delete_ingestor_stream", "failure", p.Spec.ID)
-					})
-					log.Error(err, "failed to cleanup NATS sink input stream", "stream", streamName)
-					return fmt.Errorf("cleanup NATS sink input stream %s: %w", streamName, err)
-				}
-				r.recordMetricsIfEnabled(func(m *observability.Meter) {
-					m.RecordNATSOperation(ctx, "delete_ingestor_stream", "success", p.Spec.ID)
-				})
-				log.Info("NATS sink input stream deleted successfully", "stream", streamName)
-			}
-			break // only one topic in single-topic path
-		}
-		if useDedupStreams {
-			// Delete sinkReplicas sink streams and dedupReplicas dedup input streams; do not delete
-			// s.OutputStream or s.Deduplication.OutputStream (we never created them).
-			sinkReplicas := getSinkReplicas(p)
-			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
-			for n := 0; n < sinkReplicas; n++ {
-				streamName := streamNamePrefix + "_" + strconv.Itoa(n)
-				log.Info("deleting NATS sink input stream", "stream", streamName)
-				err := r.deleteNATSStream(ctx, log, streamName)
-				if err != nil {
-					r.recordMetricsIfEnabled(func(m *observability.Meter) {
-						m.RecordNATSOperation(ctx, "delete_ingestor_stream", "failure", p.Spec.ID)
-					})
-					log.Error(err, "failed to cleanup NATS sink input stream", "stream", streamName)
-					return fmt.Errorf("cleanup NATS sink input stream %s: %w", streamName, err)
-				}
-				r.recordMetricsIfEnabled(func(m *observability.Meter) {
-					m.RecordNATSOperation(ctx, "delete_ingestor_stream", "success", p.Spec.ID)
-				})
-				log.Info("NATS sink input stream deleted successfully", "stream", streamName)
-			}
-			dedupReplicas := getDedupReplicas(p)
-			dedupInputStreamPrefix := getDedupInputStreamPrefix(p.Spec.ID, stream.TopicName)
-			for d := 0; d < dedupReplicas; d++ {
-				streamName := dedupInputStreamPrefix + "_" + strconv.Itoa(d)
-				log.Info("deleting NATS dedup input stream", "stream", streamName)
-				err := r.deleteNATSStream(ctx, log, streamName)
-				if err != nil {
-					log.Error(err, "failed to cleanup dedup input stream", "stream", streamName)
-					return fmt.Errorf("cleanup dedup input stream %s: %w", streamName, err)
-				}
-				log.Info("NATS dedup input stream deleted successfully", "stream", streamName)
-			}
-			break // only one topic in dedup N-stream path
-		}
-		streamName := getIngestorOutputSubjectPrefix(p.Spec.ID, stream.TopicName)
-		log.Info("deleting NATS ingestor output stream", "stream", streamName)
-		err := r.deleteNATSStream(ctx, log, streamName)
-		if err != nil {
-			r.recordMetricsIfEnabled(func(m *observability.Meter) {
-				m.RecordNATSOperation(ctx, "delete_ingestor_stream", "failure", p.Spec.ID)
-			})
-			log.Error(err, "failed to cleanup NATS Ingestor Output Stream", "stream", stream)
-			return fmt.Errorf("cleanup NATS Ingestor Output Stream: %w", err)
-		}
-		r.recordMetricsIfEnabled(func(m *observability.Meter) {
-			m.RecordNATSOperation(ctx, "delete_ingestor_stream", "success", p.Spec.ID)
-		})
-		log.Info("NATS ingestor output stream deleted successfully", "stream", streamName)
-
-		// Delete dedup output stream if dedup service is enabled (legacy path only; not set when useDedupNStreamPath)
-		if stream.Deduplication != nil &&
-			stream.Deduplication.Enabled {
-			dedupOutputStreamName := getDedupOutputSubjectPrefix(p.Spec.ID, stream.TopicName)
-			log.Info("deleting NATS dedup output stream", "stream", dedupOutputStreamName)
-			err := r.deleteNATSStream(ctx, log, dedupOutputStreamName)
-			if err != nil {
-				log.Error(err, "failed to cleanup dedup output stream", "stream", dedupOutputStreamName)
-				return fmt.Errorf("cleanup dedup output stream: %w", err)
-			}
-			log.Info("NATS dedup output stream deleted successfully", "stream", dedupOutputStreamName)
-		}
-	}
-
 	// delete Join Streams and key value stores
 	if p.Spec.Join.Enabled {
-		joinOutputStreamName := getJoinOutputStreamName(p.Spec.ID)
-		log.Info("deleting NATS join output stream", "stream", joinOutputStreamName)
-		err := r.deleteNATSStream(ctx, log, joinOutputStreamName)
-		if err != nil {
-			r.recordMetricsIfEnabled(func(m *observability.Meter) {
-				m.RecordNATSOperation(ctx, "delete_join_stream", "failure", p.Spec.ID)
-			})
-			log.Error(err, "failed to cleanup join output stream", "stream", joinOutputStreamName)
-			return fmt.Errorf("cleanup join output stream: %w", err)
-		}
-		r.recordMetricsIfEnabled(func(m *observability.Meter) {
-			m.RecordNATSOperation(ctx, "delete_join_stream", "success", p.Spec.ID)
-		})
-		log.Info("NATS join output stream deleted successfully", "stream", joinOutputStreamName)
+		streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
+		streamName := streamNamePrefix + "_0"
 
-		err = r.cleanupNATSPipelineJoinKeyValueStore(ctx, log, p)
+		err = r.deleteNATSStream(ctx, log, streamName)
 		if err != nil {
-			r.recordMetricsIfEnabled(func(m *observability.Meter) {
-				m.RecordNATSOperation(ctx, "delete_join_kv", "failure", p.Spec.ID)
-			})
-			log.Error(err, "failed to cleanup NATS join KV store", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
-			return fmt.Errorf("failed cleanup NATS join KV store: %w", err)
+			return fmt.Errorf("delete stream %s: %w", streamName, err)
 		}
-		r.recordMetricsIfEnabled(func(m *observability.Meter) {
-			m.RecordNATSOperation(ctx, "delete_join_kv", "success", p.Spec.ID)
-		})
+
+		// delete join KV stores
+		for _, stream := range p.Spec.Ingestor.Streams {
+			kvStreamName := getJoinInputStreamName(p, stream)
+
+			err := r.NATSClient.JetStream().DeleteKeyValue(ctx, kvStreamName)
+			if err != nil {
+				log.Error(err, "failed to delete join key-value store", "pipeline", p.Name, "pipeline_id", p.Spec.ID, "stream", streamName)
+				return fmt.Errorf("failed to delete NATS KV Store: %w", err)
+			}
+
+			err = r.deleteNATSStream(ctx, log, kvStreamName)
+			if err != nil {
+				return fmt.Errorf("delete stream %s: %w", kvStreamName, err)
+			}
+		}
+
+	} else {
+		source := p.Spec.Ingestor.Streams[0]
+		if isDedupEnabled(p) {
+			// create dedup input / ingestor output streams
+			dedupInputStreamPrefix := getDedupInputStreamPrefix(p.Spec.ID, source.TopicName)
+			dedupReplicas := getDedupReplicas(p)
+			for d := 0; d < dedupReplicas; d++ {
+				streamName := dedupInputStreamPrefix + "_" + strconv.Itoa(d)
+
+				err := r.deleteNATSStream(ctx, log, streamName)
+				if err != nil {
+					return fmt.Errorf("delete stream %s: %w", streamName, err)
+				}
+			}
+		}
+
+		// create sink input stream (ingestor/dedup output stream)
+		sinkReplicas := getSinkReplicas(p)
+		for n := 0; n < sinkReplicas; n++ {
+			streamNamePrefix := getSinkInputStreamPrefix(p.Spec.ID)
+			streamName := streamNamePrefix + "_" + strconv.Itoa(n)
+			err := r.deleteNATSStream(ctx, log, streamName)
+			if err != nil {
+				return fmt.Errorf("delete stream %s: %w", streamName, err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -30,9 +30,6 @@ import (
 )
 
 func getJoinInputStreamName(p etlv1alpha1.Pipeline, stream etlv1alpha1.SourceStream) string {
-	if stream.Deduplication != nil && stream.Deduplication.Enabled {
-		return getDedupOutputSubjectPrefix(p.Spec.ID, stream.TopicName)
-	}
 	return getIngestorOutputSubjectPrefix(p.Spec.ID, stream.TopicName)
 }
 

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -316,29 +316,6 @@ func (r *PipelineReconciler) cleanupNATSPipelineResources(ctx context.Context, l
 	return nil
 }
 
-// cleanupNATSPipelineJoinKeyValueStore cleans up NATS join key value stores
-func (r *PipelineReconciler) cleanupNATSPipelineJoinKeyValueStore(ctx context.Context, log logr.Logger, p etlv1alpha1.Pipeline) error {
-	log.Info("cleaning up NATS join key value store", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
-
-	if r.NATSClient == nil {
-		log.Info("NATS client not available, skipping key value store cleanup")
-		return fmt.Errorf("NATS client not available, skipping NATS cleanup")
-	}
-
-	// Since join key-value names are the same as join input stream names.
-	for _, stream := range p.Spec.Ingestor.Streams {
-		streamName := getJoinInputStreamName(p, stream)
-		err := r.NATSClient.JetStream().DeleteKeyValue(ctx, streamName)
-		if err != nil {
-			log.Error(err, "failed to delete join key-value store", "pipeline", p.Name, "pipeline_id", p.Spec.ID, "stream", streamName)
-			return fmt.Errorf("failed to delete NATS KV Store: %w", err)
-		}
-	}
-
-	log.Info("NATS join key value store deleted successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
-	return nil
-}
-
 // deleteNATSStream deletes a NATS stream
 func (r *PipelineReconciler) deleteNATSStream(ctx context.Context, log logr.Logger, streamName string) error {
 	if r.NATSClient == nil {

--- a/internal/controller/nats_names.go
+++ b/internal/controller/nats_names.go
@@ -36,8 +36,8 @@ const NATSConsumerNamePrefix = "gf-nats"
 // DLQSuffix is the DLQ stream suffix (aligned with glassflow-api).
 const DLQSuffix = "DLQ"
 
-// generateStreamHash returns the first 8 hex chars of SHA256(pipelineID), aligned with glassflow-api GenerateStreamHash.
-func generateStreamHash(pipelineID string) string {
+// generatePipelineHash returns the first 8 hex chars of SHA256(pipelineID), aligned with glassflow-api GenerateStreamHash.
+func generatePipelineHash(pipelineID string) string {
 	hash := sha256.Sum256([]byte(pipelineID))
 	return hex.EncodeToString(hash[:])[:8]
 }
@@ -50,32 +50,32 @@ func sanitizeNATSSubject(topicName string) string {
 // getIngestorOutputSubjectPrefix returns the subject prefix for ingestor output (aligned with glassflow-api GetIngestorStreamName).
 // Ingestor publishes to subjectPrefix.POD_INDEX (e.g. gf-abc12345-topic.0).
 func getIngestorOutputSubjectPrefix(pipelineID, topicName string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	sanitized := sanitizeNATSSubject(topicName)
-	streamName := fmt.Sprintf("%s-%s-%s", PipelineStreamPrefix, hash, sanitized)
-	if len(streamName) > MaxStreamNameLength {
+	subjectName := fmt.Sprintf("%s-%s-%s", PipelineStreamPrefix, hash, sanitized)
+	if len(subjectName) > MaxStreamNameLength {
 		prefix := fmt.Sprintf("%s-%s-", PipelineStreamPrefix, hash)
 		maxTopicLength := MaxStreamNameLength - len(prefix)
 		if maxTopicLength > 0 {
-			streamName = prefix + sanitized[:min(len(sanitized), maxTopicLength)]
+			subjectName = prefix + sanitized[:min(len(sanitized), maxTopicLength)]
 		} else {
-			streamName = prefix[:MaxStreamNameLength]
+			subjectName = prefix[:MaxStreamNameLength]
 		}
 	}
-	return streamName
+	return subjectName
 }
 
 // getSinkInputStreamPrefix returns the stream name prefix for sink input streams (aligned with glassflow-api GetNATSSinkConsumerName).
 // Sink pod index j consumes from stream prefix_j (e.g. gf-abc12345-sink_0).
 func getSinkInputStreamPrefix(pipelineID string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	return fmt.Sprintf("%s-%s-sink", PipelineStreamPrefix, hash)
 }
 
 // getDedupInputStreamPrefix returns the stream name prefix for the dedupReplicas streams that dedup reads from.
 // Stream names are prefix_0, ..., prefix_(dedupReplicas-1). Same length/truncation rules as getIngestorOutputSubjectPrefix.
 func getDedupInputStreamPrefix(pipelineID, topicName string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	sanitized := sanitizeNATSSubject(topicName)
 	streamName := fmt.Sprintf("%s-%s-%s-dedup-in", PipelineStreamPrefix, hash, sanitized)
 	if len(streamName) > MaxStreamNameLength {
@@ -93,29 +93,40 @@ func getDedupInputStreamPrefix(pipelineID, topicName string) string {
 // getDedupOutputSubjectPrefix returns the subject prefix for dedup output. Dedup pod d publishes to prefix.d.
 // Same length/truncation rules as getIngestorOutputSubjectPrefix.
 func getDedupOutputSubjectPrefix(pipelineID, topicName string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	sanitized := sanitizeNATSSubject(topicName)
-	streamName := fmt.Sprintf("%s-%s-%s-dedup-out", PipelineStreamPrefix, hash, sanitized)
-	if len(streamName) > MaxStreamNameLength {
+	subjectName := fmt.Sprintf("%s-%s-%s-dedup-out", PipelineStreamPrefix, hash, sanitized)
+	if len(subjectName) > MaxStreamNameLength {
 		prefix := fmt.Sprintf("%s-%s-", PipelineStreamPrefix, hash)
 		maxTopicLength := MaxStreamNameLength - len(prefix) - len("-dedup-out")
 		if maxTopicLength > 0 {
-			streamName = prefix + sanitized[:min(len(sanitized), maxTopicLength)] + "-dedup-out"
+			subjectName = prefix + sanitized[:min(len(sanitized), maxTopicLength)] + "-dedup-out"
 		} else {
-			streamName = (prefix + "dedup-out")[:MaxStreamNameLength]
+			subjectName = (prefix + "dedup-out")[:MaxStreamNameLength]
 		}
 	}
-	return streamName
+	return subjectName
+}
+
+// getJoinOutputSubjectPrefix returns the subject prefix for join output.
+func getJoinOutputSubjectPrefix(pipelineID string) string {
+	hash := generatePipelineHash(pipelineID)
+	subjectName := fmt.Sprintf("%s-%s-join-out", PipelineStreamPrefix, hash)
+	if len(subjectName) > MaxStreamNameLength {
+		prefix := fmt.Sprintf("%s-%s", PipelineStreamPrefix, hash)
+		subjectName = (prefix + "join-out")[:MaxStreamNameLength]
+	}
+	return subjectName
 }
 
 // getJoinOutputStreamName returns the stream name for join output.
 func getJoinOutputStreamName(pipelineID string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	return fmt.Sprintf("%s-%s-join", PipelineStreamPrefix, hash)
 }
 
 func getDLQStreamName(pipelineID string) string {
-	hash := generateStreamHash(pipelineID)
+	hash := generatePipelineHash(pipelineID)
 	return fmt.Sprintf("%s-%s-%s", PipelineStreamPrefix, hash, DLQSuffix)
 }
 
@@ -135,7 +146,7 @@ func getNATSConsumerName(pipelineID, componentType, streamType string) string {
 		NATSConsumerNamePrefix,
 		componentAbbr[componentType],
 		streamAbbr[streamType],
-		generateStreamHash(pipelineID))
+		generatePipelineHash(pipelineID))
 }
 
 func getNATSSinkConsumerName(pipelineID string) string {

--- a/internal/storage/postgres/helpers.go
+++ b/internal/storage/postgres/helpers.go
@@ -2,8 +2,6 @@ package postgres
 
 import (
 	"fmt"
-
-	"github.com/google/uuid"
 )
 
 // ErrPipelineNotExists is returned when a pipeline is not found
@@ -15,12 +13,4 @@ func checkRowsAffected(rowsAffected int64) error {
 		return ErrPipelineNotExists
 	}
 	return nil
-}
-
-// handleTransformationIDs handles NULL transformation_ids from database
-func handleTransformationIDs(transformationIDsPtr *[]uuid.UUID) []uuid.UUID {
-	if transformationIDsPtr != nil {
-		return *transformationIDsPtr
-	}
-	return []uuid.UUID{}
 }

--- a/internal/storage/postgres/pipelines.go
+++ b/internal/storage/postgres/pipelines.go
@@ -167,62 +167,8 @@ func (s *PostgresStorage) insertPipelineHistoryEvent(ctx context.Context, tx pgx
 func (s *PostgresStorage) DeletePipeline(ctx context.Context, pipelineID string) error {
 	s.logger.Info("deleting pipeline", "pipeline_id", pipelineID)
 
-	// Get pipeline row to find associated entity IDs
-	row, err := s.loadPipelineRow(ctx, pipelineID)
-	if err != nil {
-		if err == ErrPipelineNotExists {
-			return err
-		}
-		return fmt.Errorf("load pipeline row: %w", err)
-	}
-
-	// Get transformation IDs
-	transformationIDs := handleTransformationIDs(row.transformationIDsPtr)
-
-	// Get connection IDs from source and sink
-	var kafkaConnID, chConnID uuid.UUID
-	err = s.pool.QueryRow(ctx, `
-		SELECT connection_id FROM sources WHERE id = $1
-	`, row.sourceID).Scan(&kafkaConnID)
-	if err != nil {
-		return fmt.Errorf("get kafka connection ID: %w", err)
-	}
-
-	err = s.pool.QueryRow(ctx, `
-		SELECT connection_id FROM sinks WHERE id = $1
-	`, row.sinkID).Scan(&chConnID)
-	if err != nil {
-		return fmt.Errorf("get clickhouse connection ID: %w", err)
-	}
-
-	// Begin transaction for atomic deletion
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
-	}
-	committed := false
-	defer func() {
-		if !committed {
-			if err := tx.Rollback(ctx); err != nil {
-				s.logger.Error(err, "failed to rollback transaction")
-			}
-		}
-	}()
-
-	// 1. Delete transformations (no foreign key constraints)
-	if len(transformationIDs) > 0 {
-		_, err = tx.Exec(ctx, `
-			DELETE FROM transformations WHERE id = ANY($1)
-		`, transformationIDs)
-		if err != nil {
-			return fmt.Errorf("delete transformations: %w", err)
-		}
-	}
-
-	// 2. Delete pipeline (CASCADE will delete schemas and pipeline_history)
-	commandTag, err := tx.Exec(ctx, `
-		DELETE FROM pipelines WHERE id = $1
-	`, pipelineID)
+	// Delete pipeline
+	commandTag, err := s.pool.Exec(ctx, ` DELETE FROM pipelines WHERE id = $1 `, pipelineID)
 	if err != nil {
 		return fmt.Errorf("delete pipeline: %w", err)
 	}
@@ -231,51 +177,6 @@ func (s *PostgresStorage) DeletePipeline(ctx context.Context, pipelineID string)
 		return err
 	}
 
-	// 3. Delete sources (no longer referenced by pipeline)
-	_, err = tx.Exec(ctx, `
-		DELETE FROM sources WHERE id = $1
-	`, row.sourceID)
-	if err != nil {
-		return fmt.Errorf("delete source: %w", err)
-	}
-
-	// 4. Delete sinks (no longer referenced by pipeline)
-	_, err = tx.Exec(ctx, `
-		DELETE FROM sinks WHERE id = $1
-	`, row.sinkID)
-	if err != nil {
-		return fmt.Errorf("delete sink: %w", err)
-	}
-
-	// 5. Delete connections (no longer referenced by sources/sinks)
-	_, err = tx.Exec(ctx, `
-		DELETE FROM connections WHERE id = $1
-	`, kafkaConnID)
-	if err != nil {
-		return fmt.Errorf("delete kafka connection: %w", err)
-	}
-
-	// Only delete ClickHouse connection if it's different from Kafka connection
-	if chConnID != kafkaConnID {
-		_, err = tx.Exec(ctx, `
-			DELETE FROM connections WHERE id = $1
-		`, chConnID)
-		if err != nil {
-			return fmt.Errorf("delete clickhouse connection: %w", err)
-		}
-	}
-
-	// Commit transaction
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("commit transaction: %w", err)
-	}
-	committed = true
-
-	s.logger.Info("pipeline and all associated entities deleted successfully",
-		"pipeline_id", pipelineID,
-		"transformations_deleted", len(transformationIDs),
-		"source_id", row.sourceID.String(),
-		"sink_id", row.sinkID.String())
-
+	s.logger.Info("pipeline and all associated entities deleted successfully", "pipeline_id", pipelineID)
 	return nil
 }

--- a/internal/storage/postgres/pipelines.go
+++ b/internal/storage/postgres/pipelines.go
@@ -6,68 +6,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
 )
-
-// pipelineRow represents a row from the pipelines table
-type pipelineRow struct {
-	pipelineID           string
-	name                 string
-	status               string
-	sourceID             uuid.UUID
-	sinkID               uuid.UUID
-	transformationIDsPtr *[]uuid.UUID
-	metadataJSON         []byte
-	createdAt            time.Time
-	updatedAt            time.Time
-}
-
-// loadPipelineRow loads a pipeline row from the database
-func (s *PostgresStorage) loadPipelineRow(ctx context.Context, pipelineID string) (*pipelineRow, error) {
-	var row pipelineRow
-	var transformationIDsArray pgtype.Array[pgtype.UUID]
-
-	err := s.pool.QueryRow(ctx, `
-		SELECT id, name, status, source_id, sink_id, transformation_ids, metadata, created_at, updated_at
-		FROM pipelines
-		WHERE id = $1
-	`, pipelineID).Scan(
-		&row.pipelineID,
-		&row.name,
-		&row.status,
-		&row.sourceID,
-		&row.sinkID,
-		&transformationIDsArray,
-		&row.metadataJSON,
-		&row.createdAt,
-		&row.updatedAt,
-	)
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			s.logger.V(1).Info("pipeline not found", "pipeline_id", pipelineID)
-			return nil, ErrPipelineNotExists
-		}
-		s.logger.Error(err, "failed to load pipeline row", "pipeline_id", pipelineID)
-		return nil, fmt.Errorf("get pipeline: %w", err)
-	}
-
-	// Convert pgtype UUID array to []uuid.UUID
-	if transformationIDsArray.Valid {
-		transformationIDs := make([]uuid.UUID, 0, len(transformationIDsArray.Elements))
-		for _, elem := range transformationIDsArray.Elements {
-			if elem.Valid {
-				transformationIDs = append(transformationIDs, elem.Bytes)
-			}
-		}
-		row.transformationIDsPtr = &transformationIDs
-	}
-
-	return &row, nil
-}
 
 // UpdatePipelineStatus updates the pipeline status and creates a history event
 func (s *PostgresStorage) UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string) error {


### PR DESCRIPTION
1. Nats consumer name contracts different between components and operator
2. Ingestor and Sink teardown should check stateful set instead of deployment resource
3. Simplify delete pipeline from DB (cascade)
4. Simplify NATS stream creation (subject-stream mapping flow)
5. Simplify NATS stream cleanup 
6. Convert join component to be stateful set