### PR TITLE
fix: component label length

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -300,7 +300,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 
 	labels := preparePipelineLabels(p)
 
-	secretName := r.getResourceName(p, constants.SecretSuffix)
+	secretName := r.getResourceName(p)
 	secret, err := r.createSecret(ctx, types.NamespacedName{Namespace: ns.GetName(), Name: secretName}, labels, p)
 	if err != nil {
 		if errors.Is(err, ErrPipelineConfigSecretNotFound) {
@@ -661,7 +661,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 	}
 
 	// Get secret
-	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, constants.SecretSuffix)}
+	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p)}
 	var secret v1.Secret
 	err = r.Get(ctx, secretName, &secret)
 	if err != nil {
@@ -840,7 +840,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 
 	// Update the pipeline config secret with new config
 	labels := preparePipelineLabels(p)
-	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p, constants.SecretSuffix)}
+	secretName := types.NamespacedName{Namespace: namespace, Name: r.getResourceName(p)}
 	secret, err := r.updateSecret(ctx, secretName, labels, p)
 	if err != nil {
 		if errors.Is(err, ErrPipelineConfigSecretNotFound) {

--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -59,7 +59,7 @@ func (r *PipelineReconciler) createPipelineComponents(
 	namespace := r.getTargetNamespace(*p)
 
 	// Step 1: Ensure Sink StatefulSet is ready
-	requeue, err := r.ensureStatefulSetReady(ctx, log, p, namespace, r.getResourceName(*p, constants.SinkComponent), r.createSink, ns, labels, secret)
+	requeue, err := r.ensureStatefulSetReady(ctx, log, p, namespace, r.getStatefulSetResourceName(*p, constants.SinkComponent), r.createSink, ns, labels, secret)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -69,7 +69,7 @@ func (r *PipelineReconciler) createPipelineComponents(
 
 	// Step 2: Ensure Join StatefulSet is ready (if enabled)
 	if p.Spec.Join.Enabled {
-		requeue, err = r.ensureStatefulSetReady(ctx, log, p, namespace, r.getResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
+		requeue, err = r.ensureStatefulSetReady(ctx, log, p, namespace, r.getStatefulSetResourceName(*p, constants.JoinComponent), r.createJoin, ns, labels, secret)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -86,7 +86,7 @@ func (r *PipelineReconciler) createPipelineComponents(
 
 	// Step 4: Ensure Ingestor StatefulSets are ready
 	for i := range p.Spec.Ingestor.Streams {
-		statefulSetName := r.getResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
+		statefulSetName := r.getStatefulSetResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 		ready, err := r.isStatefulSetReady(ctx, namespace, statefulSetName)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("check ingestor statefulset %s: %w", statefulSetName, err)
@@ -114,7 +114,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 	ing := p.Spec.Ingestor
 
 	for i, t := range ing.Streams {
-		resourceRef := r.getResourceName(p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
+		resourceRef := r.getStatefulSetResourceName(p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 
 		ingestorLabels := r.getKafkaIngestorLabels(t.TopicName)
 		maps.Copy(ingestorLabels, labels)
@@ -232,7 +232,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 		return fmt.Errorf("join requires at least 2 source streams")
 	}
 
-	resourceRef := r.getResourceName(p, constants.JoinComponent)
+	resourceRef := r.getStatefulSetResourceName(p, constants.JoinComponent)
 	namespace := ns.GetName()
 
 	joinLabels := r.getJoinLabels()
@@ -331,7 +331,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 
 // createSink creates a sink StatefulSet (and headless Service) for the pipeline.
 func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, labels map[string]string, secret v1.Secret, p etlv1alpha1.Pipeline) error {
-	resourceRef := r.getResourceName(p, constants.SinkComponent)
+	resourceRef := r.getStatefulSetResourceName(p, constants.SinkComponent)
 	namespace := ns.GetName()
 
 	sinkLabels := r.getSinkLabels()
@@ -432,7 +432,7 @@ func (r *PipelineReconciler) createDedups(ctx context.Context, _ logr.Logger, ns
 			continue
 		}
 
-		resourceRef := r.getResourceName(p, fmt.Sprintf("dedup-%d", i))
+		resourceRef := r.getStatefulSetResourceName(p, fmt.Sprintf("dedup-%d", i))
 		serviceName := resourceRef
 
 		dedupLabels := r.getDedupLabels(stream.TopicName)
@@ -609,7 +609,7 @@ func (r *PipelineReconciler) areDedupStatefulSetsReady(
 			continue
 		}
 
-		dedupName := r.getResourceName(p, fmt.Sprintf("%s-%d", constants.DedupComponent, i))
+		dedupName := r.getStatefulSetResourceName(p, fmt.Sprintf("%s-%d", constants.DedupComponent, i))
 		ready, err := r.isStatefulSetReady(ctx, namespace, dedupName)
 		if err != nil {
 			return false, fmt.Errorf("check dedup-%d statefulset: %w", i, err)
@@ -723,7 +723,7 @@ func (r *PipelineReconciler) reconcileIngestorTeardown(
 			return result, err
 		}
 
-		deploymentName := r.getResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
+		deploymentName := r.getStatefulSetResourceName(*p, fmt.Sprintf("%s-%d", constants.IngestorComponent, i))
 		result, err = r.ensureStatefulSetDeleted(ctx, log, namespace, "ingestor", deploymentName)
 		if err != nil || result.Requeue {
 			return result, err
@@ -761,7 +761,7 @@ func (r *PipelineReconciler) reconcileDedupTeardown(
 			}
 		}
 
-		statefulSetName := r.getResourceName(*p, fmt.Sprintf("%s-%d", constants.DedupComponent, i))
+		statefulSetName := r.getStatefulSetResourceName(*p, fmt.Sprintf("%s-%d", constants.DedupComponent, i))
 		result, err = r.ensureStatefulSetDeleted(ctx, log, namespace, "dedup", statefulSetName)
 		if err != nil || result.Requeue {
 			return result, err
@@ -803,7 +803,7 @@ func (r *PipelineReconciler) reconcileJoinTeardown(
 		return result, err
 	}
 
-	statefulSetName := r.getResourceName(*p, constants.JoinComponent)
+	statefulSetName := r.getStatefulSetResourceName(*p, constants.JoinComponent)
 	return r.ensureStatefulSetDeleted(ctx, log, namespace, constants.JoinComponent, statefulSetName)
 }
 
@@ -835,7 +835,7 @@ func (r *PipelineReconciler) reconcileSinkTeardown(
 		return result, err
 	}
 
-	deploymentName := r.getResourceName(*p, constants.SinkComponent)
+	deploymentName := r.getStatefulSetResourceName(*p, constants.SinkComponent)
 	return r.ensureStatefulSetDeleted(ctx, log, namespace, constants.SinkComponent, deploymentName)
 }
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -27,6 +27,12 @@ import (
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
 )
 
+const (
+	pipelineScopedResourcePrefix       = "gf-"
+	maxK8sResourceNameLength           = 63
+	maxStatefulSetNameLengthForRevHash = 52 // controller-revision-hash label value is "<sts-name>-<10 chars>"
+)
+
 // getKafkaIngestorLabels returns labels for Kafka ingestor components
 func (r *PipelineReconciler) getKafkaIngestorLabels(topic string) map[string]string {
 	labels := map[string]string{
@@ -168,10 +174,32 @@ func (r *PipelineReconciler) isOperatorManagedNamespace(ns v1.Namespace) bool {
 
 // getResourceName generates a unique resource name for the given pipeline
 func (r *PipelineReconciler) getResourceName(p etlv1alpha1.Pipeline, baseName string) string {
+	return r.getPipelineScopedResourceName(p, baseName, maxK8sResourceNameLength)
+}
+
+// getStatefulSetResourceName generates a StatefulSet resource name that keeps
+// controller-revision-hash label values within Kubernetes' 63-char limit.
+func (r *PipelineReconciler) getStatefulSetResourceName(p etlv1alpha1.Pipeline, baseName string) string {
+	return r.getPipelineScopedResourceName(p, baseName, maxStatefulSetNameLengthForRevHash)
+}
+
+func (r *PipelineReconciler) getPipelineScopedResourceName(p etlv1alpha1.Pipeline, baseName string, maxLen int) string {
 	if r.PipelinesNamespaceAuto {
 		return baseName
 	}
-	return fmt.Sprintf("gf-pipeline-%s-%s", p.Spec.ID, baseName)
+
+	// Format: gf-<pipeline-id>-<baseName>
+	reserved := len(pipelineScopedResourcePrefix) + 1 + len(baseName)
+	availableForPipelineID := maxLen - reserved
+	pipelineID := p.Spec.ID
+	if availableForPipelineID < 1 {
+		availableForPipelineID = 1
+	}
+	if len(pipelineID) > availableForPipelineID {
+		pipelineID = pipelineID[:availableForPipelineID]
+	}
+
+	return fmt.Sprintf("%s%s-%s", pipelineScopedResourcePrefix, pipelineID, baseName)
 }
 
 // ptrInt32 returns a pointer to an int32

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -173,8 +173,8 @@ func (r *PipelineReconciler) isOperatorManagedNamespace(ns v1.Namespace) bool {
 }
 
 // getResourceName generates a unique resource name for the given pipeline
-func (r *PipelineReconciler) getResourceName(p etlv1alpha1.Pipeline, baseName string) string {
-	return r.getPipelineScopedResourceName(p, baseName, maxK8sResourceNameLength)
+func (r *PipelineReconciler) getResourceName(p etlv1alpha1.Pipeline) string {
+	return r.getPipelineScopedResourceName(p, constants.SecretSuffix, maxK8sResourceNameLength)
 }
 
 // getStatefulSetResourceName generates a StatefulSet resource name that keeps

--- a/internal/controller/helpers_resource_name_test.go
+++ b/internal/controller/helpers_resource_name_test.go
@@ -50,7 +50,7 @@ func TestGetResourceNameDoesNotTruncateCurrentSecretNames(t *testing.T) {
 		},
 	}
 
-	name := reconciler.getResourceName(pipeline, "secret")
+	name := reconciler.getResourceName(pipeline)
 
 	expectedName := fmt.Sprintf("%s%s-%s", pipelineScopedResourcePrefix, pipeline.Spec.ID, "secret")
 	if name != expectedName {
@@ -74,7 +74,7 @@ func TestPipelineScopedResourceNameAutoNamespaceUsesBaseName(t *testing.T) {
 		},
 	}
 
-	if got, want := reconciler.getResourceName(pipeline, "secret"), "secret"; got != want {
+	if got, want := reconciler.getResourceName(pipeline), "secret"; got != want {
 		t.Fatalf("unexpected resource name: got=%q want=%q", got, want)
 	}
 	if got, want := reconciler.getStatefulSetResourceName(pipeline, "ingestor-0"), "ingestor-0"; got != want {

--- a/internal/controller/helpers_resource_name_test.go
+++ b/internal/controller/helpers_resource_name_test.go
@@ -1,0 +1,83 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+)
+
+func TestGetStatefulSetResourceNameTruncatesPipelineID(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{PipelinesNamespaceAuto: false}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "abcdefghijklmnopqrstuvwxyz1234567890abcd", // 40 chars
+		},
+	}
+
+	name := reconciler.getStatefulSetResourceName(pipeline, "ingestor-0")
+
+	expectedPipelineIDLen := maxStatefulSetNameLengthForRevHash - (len(pipelineScopedResourcePrefix) + 1 + len("ingestor-0"))
+	expectedPipelineID := pipeline.Spec.ID[:expectedPipelineIDLen]
+	expectedName := fmt.Sprintf("%s%s-%s", pipelineScopedResourcePrefix, expectedPipelineID, "ingestor-0")
+	if name != expectedName {
+		t.Fatalf("unexpected truncated statefulset name: got=%q want=%q", name, expectedName)
+	}
+
+	if got, want := len(name), maxStatefulSetNameLengthForRevHash; got != want {
+		t.Fatalf("unexpected statefulset name length: got=%d want=%d name=%q", got, want, name)
+	}
+	if !strings.HasSuffix(name, "-ingestor-0") {
+		t.Fatalf("statefulset name must preserve base suffix, got %q", name)
+	}
+
+	// StatefulSet controller appends "-<10 chars>" for controller revisions.
+	if got, want := len(name)+11, 63; got != want {
+		t.Fatalf("controller-revision label value length must fit 63 chars: got=%d want=%d", got, want)
+	}
+}
+
+func TestGetResourceNameDoesNotTruncateCurrentSecretNames(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{PipelinesNamespaceAuto: false}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "abcdefghijklmnopqrstuvwxyz1234567890abcd", // 40 chars
+		},
+	}
+
+	name := reconciler.getResourceName(pipeline, "secret")
+
+	expectedName := fmt.Sprintf("%s%s-%s", pipelineScopedResourcePrefix, pipeline.Spec.ID, "secret")
+	if name != expectedName {
+		t.Fatalf("unexpected secret name: got=%q want=%q", name, expectedName)
+	}
+	if got, want := len(name), len(expectedName); got != want {
+		t.Fatalf("unexpected secret name length: got=%d want=%d name=%q", got, want, name)
+	}
+	if !strings.HasPrefix(name, pipelineScopedResourcePrefix) {
+		t.Fatalf("resource name must keep prefix %q, got %q", pipelineScopedResourcePrefix, name)
+	}
+}
+
+func TestPipelineScopedResourceNameAutoNamespaceUsesBaseName(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{PipelinesNamespaceAuto: true}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "very-long-pipeline-id-that-should-not-matter-here",
+		},
+	}
+
+	if got, want := reconciler.getResourceName(pipeline, "secret"), "secret"; got != want {
+		t.Fatalf("unexpected resource name: got=%q want=%q", got, want)
+	}
+	if got, want := reconciler.getStatefulSetResourceName(pipeline, "ingestor-0"), "ingestor-0"; got != want {
+		t.Fatalf("unexpected statefulset resource name: got=%q want=%q", got, want)
+	}
+}

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -468,7 +468,7 @@ func (r *PipelineReconciler) cleanupDedupPVCs(ctx context.Context, log logr.Logg
 			continue
 		}
 
-		dedupName := r.getResourceName(p, fmt.Sprintf("dedup-%d", i))
+		dedupName := r.getStatefulSetResourceName(p, fmt.Sprintf("dedup-%d", i))
 
 		replicas := getDedupReplicas(p)
 

--- a/internal/controller/k8s_resources.go
+++ b/internal/controller/k8s_resources.go
@@ -267,7 +267,7 @@ func (r *PipelineReconciler) deleteSecret(ctx context.Context, log logr.Logger, 
 		return nil
 	}
 
-	secretName := types.NamespacedName{Namespace: r.PipelinesNamespaceName, Name: r.getResourceName(p, constants.SecretSuffix)}
+	secretName := types.NamespacedName{Namespace: r.PipelinesNamespaceName, Name: r.getResourceName(p)}
 	var secret v1.Secret
 	err := r.Get(ctx, secretName, &secret)
 	if err != nil {


### PR DESCRIPTION
Tested pipeline ID - demo-llm-otel-logs-pipeline-2658-demo-12 (40 chars max length allowed in API)

component names generated (max allowed 63)
gf-demo-llm-otel-logs-pipeline-2658-demo--ingestor-0-0 (54)
gf-demo-llm-otel-logs-pipeline-2658-demo--ingestor-0-1 (54)
