### PR TITLE
fix: Duplicate app.kubernetes.io/name label in deployment.yaml

### DIFF
--- a/charts/glassflow-operator/Chart.yaml
+++ b/charts/glassflow-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.6
+version: 0.7.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -16,12 +16,14 @@ spec:
       labels:
         control-plane: controller-manager
       {{- include "glassflow-operator.selectorLabels" . | nindent 8 }}
+      {{- $defaultPodAnnotations := dict
+          "kubectl.kubernetes.io/default-container" "manager"
+          "checksum/config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum)
+      }}
+      {{- $podAnnotations := .Values.podAnnotations | default dict }}
+      {{- $mergedPodAnnotations := mergeOverwrite (dict) $podAnnotations $defaultPodAnnotations }}
       annotations:
-        kubectl.kubernetes.io/default-container: manager
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $mergedPodAnnotations | nindent 8 }}
     spec:
       {{- with .Values.controllerManager.manager.nodeSelector }}
       nodeSelector:

--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -9,13 +9,11 @@ spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: glassflow-etl-k8s-operator
       control-plane: controller-manager
     {{- include "glassflow-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: glassflow-etl-k8s-operator
         control-plane: controller-manager
       {{- include "glassflow-operator.selectorLabels" . | nindent 8 }}
       annotations:


### PR DESCRIPTION
Fixes #142 

1. Removed hardcoded labels from deployment.yaml, added by _helpers.tpl already
2. If conflicting podAnnotations, use mergeOverwrite to render unique annotations 
