### PR TITLE
ETL-858: refactor operator v4

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -138,24 +138,7 @@ func (r *PipelineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		if operation == constants.OperationHelmUninstall {
 			log.Info("HELM UNINSTALL detected - interrupting any ongoing operations", "pipeline_id", p.Spec.ID)
 		}
-
-		// Execute the appropriate operation
-		switch operation {
-		case constants.OperationHelmUninstall:
-			return r.reconcileHelmUninstall(ctx, log, p)
-		case constants.OperationCreate:
-			return r.createPipeline(ctx, p)
-		case constants.OperationResume:
-			return r.reconcileResume(ctx, log, p)
-		case constants.OperationStop:
-			return r.reconcileStop(ctx, log, p)
-		case constants.OperationEdit:
-			return r.reconcileEdit(ctx, log, p)
-		case constants.OperationTerminate:
-			return r.reconcileTerminate(ctx, log, p)
-		case constants.OperationDelete:
-			return r.reconcileDelete(ctx, log, p)
-		}
+		return r.dispatchOperation(ctx, log, operation, p)
 	}
 
 	// No operation needed
@@ -187,13 +170,8 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, nil
 	}
 
-	// Check for timeout before proceeding
-	timedOut, elapsed := r.checkOperationTimeout(log, &p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, &p)
-	}
-	if elapsed > 0 {
-		log.Info("operation in progress", "pipeline_id", pipelineID, "elapsed", elapsed)
+	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
+		return result, err
 	}
 
 	if p.Status == etlv1alpha1.PipelineStatus(models.PipelineStatusCreated) {
@@ -210,12 +188,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 			return ctrl.Result{}, fmt.Errorf("update pipeline CRD status: %w", err)
 		}
 
-		// Set operation start time when transitioning to Created status
-		err = r.setOperationStartTime(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to set operation start time", "pipeline_id", pipelineID)
-			// Continue anyway - this is not critical
-		}
+		r.setOperationStartTimeBestEffort(ctx, log, &p)
 	}
 
 	ns, err := r.createNamespace(ctx, p)
@@ -262,26 +235,15 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
 
-	// Remove create annotation and clear operation start time
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineCreateAnnotation)
-		r.clearOperationStartTime(&p)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusRunning)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove create annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
-
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "create", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "create", pipelineID)
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineCreateAnnotation,
+		models.PipelineStatusRunning,
+		true,
+	)
+	r.recordOperationSuccess(ctx, "create", "create", pipelineID)
 
 	log.Info("pipeline creation completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -298,21 +260,11 @@ func (r *PipelineReconciler) reconcileTerminate(ctx context.Context, log logr.Lo
 		return ctrl.Result{}, nil
 	}
 
-	// Check for timeout before proceeding
-	timedOut, elapsed := r.checkOperationTimeout(log, &p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, &p)
-	}
-	if elapsed > 0 {
-		log.Info("operation in progress", "pipeline_id", pipelineID, "elapsed", elapsed)
+	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
+		return result, err
 	}
 
-	// Set operation start time if not already set (for timeout usage stats)
-	err := r.setOperationStartTime(ctx, &p)
-	if err != nil {
-		log.Error(err, "failed to set operation start time", "pipeline_id", pipelineID)
-		// Continue anyway - this is not critical
-	}
+	r.setOperationStartTimeBestEffort(ctx, log, &p)
 
 	// Stop all pipeline components
 	result, err := r.terminatePipelineComponents(ctx, log, &p)
@@ -332,25 +284,15 @@ func (r *PipelineReconciler) reconcileTerminate(ctx context.Context, log logr.Lo
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to stopped: %w", err)
 	}
 
-	// Remove terminate annotation
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineTerminateAnnotation)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusStopped)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove terminate annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
-
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "terminate", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "terminate", pipelineID)
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineTerminateAnnotation,
+		models.PipelineStatusStopped,
+		false,
+	)
+	r.recordOperationSuccess(ctx, "terminate", "terminate", pipelineID)
 
 	log.Info("pipeline termination completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -403,17 +345,14 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 		}
 	}
 
-	// Remove terminate annotation
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineDeleteAnnotation)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusStopped)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove terminate annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineDeleteAnnotation,
+		models.PipelineStatusStopped,
+		false,
+	)
 
 	// Remove finalizer
 	err = r.removeFinalizer(ctx, &p)
@@ -427,13 +366,7 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "delete", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "delete", pipelineID)
+	r.recordOperationSuccess(ctx, "delete", "delete", pipelineID)
 
 	log.Info("pipeline deletion completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -530,13 +463,7 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "uninstall", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "helm-uninstall", pipelineID)
+	r.recordOperationSuccess(ctx, "uninstall", "helm-uninstall", pipelineID)
 
 	log.Info("pipeline helm uninstall completed successfully - FORCE CLEANUP", "pipeline", p.Name, "pipeline_id", pipelineID)
 	return ctrl.Result{}, nil
@@ -555,13 +482,8 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, nil
 	}
 
-	// Check for timeout before proceeding
-	timedOut, elapsed := r.checkOperationTimeout(log, &p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, &p)
-	}
-	if elapsed > 0 {
-		log.Info("operation in progress", "pipeline_id", pipelineID, "elapsed", elapsed)
+	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
+		return result, err
 	}
 
 	if p.Status == etlv1alpha1.PipelineStatus(models.PipelineStatusResuming) {
@@ -574,15 +496,10 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to resuming: %w", err)
 		}
 
-		// Set operation start time when transitioning to Resuming status
-		err = r.setOperationStartTime(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to set operation start time", "pipeline_id", pipelineID)
-			// Continue anyway - this is not critical
-		}
+		r.setOperationStartTimeBestEffort(ctx, log, &p)
 
 		// Requeue to continue with the resume process
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
+		return defaultOperationRequeueResult(), nil
 	}
 
 	// Get namespace
@@ -641,26 +558,15 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
 
-	// Remove resume annotation and clear operation start time
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineResumeAnnotation)
-		r.clearOperationStartTime(&p)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusRunning)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove resume annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
-
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "resume", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "resume", pipelineID)
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineResumeAnnotation,
+		models.PipelineStatusRunning,
+		true,
+	)
+	r.recordOperationSuccess(ctx, "resume", "resume", pipelineID)
 
 	log.Info("pipeline resume completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -677,13 +583,8 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, nil
 	}
 
-	// Check for timeout before proceeding
-	timedOut, elapsed := r.checkOperationTimeout(log, &p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, &p)
-	}
-	if elapsed > 0 {
-		log.Info("operation in progress", "pipeline_id", pipelineID, "elapsed", elapsed)
+	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
+		return result, err
 	}
 
 	// Check if pipeline is already stopping
@@ -697,15 +598,10 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to stopping: %w", err)
 		}
 
-		// Set operation start time when transitioning to Stopping status
-		err = r.setOperationStartTime(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to set operation start time", "pipeline_id", pipelineID)
-			// Continue anyway - this is not critical
-		}
+		r.setOperationStartTimeBestEffort(ctx, log, &p)
 
 		// Requeue to continue with the stop process
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second}, nil
+		return defaultOperationRequeueResult(), nil
 	}
 
 	// Stop all pipeline components
@@ -729,26 +625,15 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to stopped: %w", err)
 	}
 
-	// Remove stop annotation and clear operation start time
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineStopAnnotation)
-		r.clearOperationStartTime(&p)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusStopped)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove stop annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
-
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "stop", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "stop", pipelineID)
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineStopAnnotation,
+		models.PipelineStatusStopped,
+		true,
+	)
+	r.recordOperationSuccess(ctx, "stop", "stop", pipelineID)
 
 	log.Info("pipeline stop completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -761,13 +646,8 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 
 	namespace := r.getTargetNamespace(p)
 
-	// Check for timeout before proceeding
-	timedOut, elapsed := r.checkOperationTimeout(log, &p)
-	if timedOut {
-		return r.handleOperationTimeout(ctx, log, &p)
-	}
-	if elapsed > 0 {
-		log.Info("operation in progress", "pipeline_id", pipelineID, "elapsed", elapsed)
+	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
+		return result, err
 	}
 
 	// Update the pipeline config secret with new config
@@ -792,12 +672,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to resuming: %w", err)
 		}
 
-		// Set operation start time when transitioning to Resuming status
-		err = r.setOperationStartTime(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to set operation start time", "pipeline_id", pipelineID)
-			// Continue anyway - this is not critical
-		}
+		r.setOperationStartTimeBestEffort(ctx, log, &p)
 	}
 
 	// Get namespace for deployment creation
@@ -833,26 +708,15 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
 
-	// Remove edit annotation and clear operation start time
-	annotations := p.GetAnnotations()
-	if annotations != nil {
-		delete(annotations, constants.PipelineEditAnnotation)
-		r.clearOperationStartTime(&p)
-		p.SetAnnotations(annotations)
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusRunning)
-		err = r.Update(ctx, &p)
-		if err != nil {
-			log.Error(err, "failed to remove edit annotation", "pipeline_id", p.Spec.ID)
-		}
-	}
-
-	// Record success metrics
-	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, "edit", "success", pipelineID)
-	})
-
-	// Send usage stats event for reconcile success
-	r.sendReconcileSuccessEvent(ctx, "edit", pipelineID)
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		log,
+		&p,
+		constants.PipelineEditAnnotation,
+		models.PipelineStatusRunning,
+		true,
+	)
+	r.recordOperationSuccess(ctx, "edit", "edit", pipelineID)
 
 	log.Info("pipeline edit completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil

--- a/internal/controller/operations.go
+++ b/internal/controller/operations.go
@@ -1,0 +1,110 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/observability"
+)
+
+type pipelineOperationHandler func(context.Context, logr.Logger, etlv1alpha1.Pipeline) (ctrl.Result, error)
+
+func (r *PipelineReconciler) operationHandlerFor(operation string) pipelineOperationHandler {
+	handlers := map[string]pipelineOperationHandler{
+		constants.OperationHelmUninstall: r.reconcileHelmUninstall,
+		constants.OperationCreate: func(ctx context.Context, _ logr.Logger, p etlv1alpha1.Pipeline) (ctrl.Result, error) {
+			return r.createPipeline(ctx, p)
+		},
+		constants.OperationResume:    r.reconcileResume,
+		constants.OperationStop:      r.reconcileStop,
+		constants.OperationEdit:      r.reconcileEdit,
+		constants.OperationTerminate: r.reconcileTerminate,
+		constants.OperationDelete:    r.reconcileDelete,
+	}
+
+	return handlers[operation]
+}
+
+func (r *PipelineReconciler) dispatchOperation(
+	ctx context.Context,
+	log logr.Logger,
+	operation string,
+	p etlv1alpha1.Pipeline,
+) (ctrl.Result, error) {
+	handler := r.operationHandlerFor(operation)
+	if handler == nil {
+		return ctrl.Result{}, nil
+	}
+
+	return handler(ctx, log, p)
+}
+
+func (r *PipelineReconciler) checkOperationTimeoutAndLogProgress(
+	ctx context.Context,
+	log logr.Logger,
+	p *etlv1alpha1.Pipeline,
+) (ctrl.Result, bool, error) {
+	timedOut, elapsed := r.checkOperationTimeout(log, p)
+	if timedOut {
+		result, err := r.handleOperationTimeout(ctx, log, p)
+		return result, true, err
+	}
+	if elapsed > 0 {
+		log.Info("operation in progress", "pipeline_id", p.Spec.ID, "elapsed", elapsed)
+	}
+
+	return ctrl.Result{}, false, nil
+}
+
+func (r *PipelineReconciler) setOperationStartTimeBestEffort(ctx context.Context, log logr.Logger, p *etlv1alpha1.Pipeline) {
+	if err := r.setOperationStartTime(ctx, p); err != nil {
+		log.Error(err, "failed to set operation start time", "pipeline_id", p.Spec.ID)
+	}
+}
+
+func (r *PipelineReconciler) clearOperationAnnotationAndStatus(
+	ctx context.Context,
+	log logr.Logger,
+	p *etlv1alpha1.Pipeline,
+	annotationKey string,
+	finalStatus models.PipelineStatus,
+	clearStartTime bool,
+) {
+	annotations := p.GetAnnotations()
+	if annotations == nil {
+		return
+	}
+
+	delete(annotations, annotationKey)
+	if clearStartTime {
+		r.clearOperationStartTime(p)
+	}
+
+	p.SetAnnotations(annotations)
+	p.Status = etlv1alpha1.PipelineStatus(finalStatus)
+	if err := r.Update(ctx, p); err != nil {
+		log.Error(err, "failed to clear operation annotation", "pipeline_id", p.Spec.ID, "annotation", annotationKey)
+	}
+}
+
+func (r *PipelineReconciler) recordOperationSuccess(
+	ctx context.Context,
+	metricsOperation string,
+	usageStatsOperation string,
+	pipelineID string,
+) {
+	r.recordMetricsIfEnabled(func(m *observability.Meter) {
+		m.RecordReconcileOperation(ctx, metricsOperation, "success", pipelineID)
+	})
+	r.sendReconcileSuccessEvent(ctx, usageStatsOperation, pipelineID)
+}
+
+func defaultOperationRequeueResult() ctrl.Result {
+	return ctrl.Result{Requeue: true, RequeueAfter: time.Second}
+}

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -1,0 +1,370 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+)
+
+func TestOperationHandlerForKnownOperations(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{}
+
+	operations := []string{
+		constants.OperationHelmUninstall,
+		constants.OperationCreate,
+		constants.OperationResume,
+		constants.OperationStop,
+		constants.OperationEdit,
+		constants.OperationTerminate,
+		constants.OperationDelete,
+	}
+
+	for _, operation := range operations {
+		operation := operation
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			handler := r.operationHandlerFor(operation)
+			if handler == nil {
+				t.Fatalf("operationHandlerFor(%q) returned nil handler", operation)
+			}
+		})
+	}
+}
+
+func TestOperationHandlerForUnknownOperation(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{}
+	if handler := r.operationHandlerFor("unknown-operation"); handler != nil {
+		t.Fatalf("operationHandlerFor() returned handler for unknown operation")
+	}
+}
+
+func TestDispatchOperationUnknownOperationIsNoop(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{}
+	result, err := r.dispatchOperation(context.Background(), logr.Discard(), "unknown-operation", etlv1alpha1.Pipeline{})
+	if err != nil {
+		t.Fatalf("dispatchOperation() returned unexpected error: %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("dispatchOperation() returned unexpected result: %#v", result)
+	}
+}
+
+func TestDefaultOperationRequeueResult(t *testing.T) {
+	t.Parallel()
+
+	result := defaultOperationRequeueResult()
+	if !result.Requeue {
+		t.Fatalf("defaultOperationRequeueResult() expected Requeue=true, got %#v", result)
+	}
+	if result.RequeueAfter != time.Second {
+		t.Fatalf("defaultOperationRequeueResult() expected RequeueAfter=%s, got %s", time.Second, result.RequeueAfter)
+	}
+}
+
+func TestSetOperationStartTimeBestEffortSetsOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r, p := newOperationTestReconcilerWithPipeline(t, map[string]string{
+		constants.PipelineCreateAnnotation: "true",
+	})
+
+	r.setOperationStartTimeBestEffort(ctx, logr.Discard(), &p)
+	stored := getPipelineForOperationTest(t, r, p.Name, p.Namespace)
+	firstStartTime, exists := stored.Annotations[constants.PipelineOperationStartTimeAnnotation]
+	if !exists || firstStartTime == "" {
+		t.Fatalf("setOperationStartTimeBestEffort() did not set operation start time annotation")
+	}
+
+	r.setOperationStartTimeBestEffort(ctx, logr.Discard(), stored)
+	storedAgain := getPipelineForOperationTest(t, r, p.Name, p.Namespace)
+	secondStartTime := storedAgain.Annotations[constants.PipelineOperationStartTimeAnnotation]
+	if secondStartTime != firstStartTime {
+		t.Fatalf("setOperationStartTimeBestEffort() overwrote operation start time annotation")
+	}
+}
+
+func TestSetOperationStartTimeBestEffortHandlesUpdateError(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{
+		Client: &operationTestClient{
+			objects: map[types.NamespacedName]*etlv1alpha1.Pipeline{},
+		},
+	}
+
+	p := etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-pipeline",
+			Namespace: "default",
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "missing-pipeline-id",
+		},
+	}
+
+	r.setOperationStartTimeBestEffort(context.Background(), logr.Discard(), &p)
+
+	startTime := p.GetAnnotations()[constants.PipelineOperationStartTimeAnnotation]
+	if startTime == "" {
+		t.Fatalf("setOperationStartTimeBestEffort() did not set local operation start time on update error")
+	}
+}
+
+func TestClearOperationAnnotationAndStatusClearsStartTimeWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r, p := newOperationTestReconcilerWithPipeline(t, map[string]string{
+		constants.PipelineCreateAnnotation:             "true",
+		constants.PipelineOperationStartTimeAnnotation: "2026-03-16T12:00:00Z",
+		"keep": "value",
+	})
+
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		logr.Discard(),
+		&p,
+		constants.PipelineCreateAnnotation,
+		models.PipelineStatusRunning,
+		true,
+	)
+
+	stored := getPipelineForOperationTest(t, r, p.Name, p.Namespace)
+	if _, exists := stored.Annotations[constants.PipelineCreateAnnotation]; exists {
+		t.Fatalf("clearOperationAnnotationAndStatus() did not remove create annotation")
+	}
+	if _, exists := stored.Annotations[constants.PipelineOperationStartTimeAnnotation]; exists {
+		t.Fatalf("clearOperationAnnotationAndStatus() did not clear operation start time")
+	}
+	if stored.Annotations["keep"] != "value" {
+		t.Fatalf("clearOperationAnnotationAndStatus() modified unrelated annotations")
+	}
+	if stored.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusRunning) {
+		t.Fatalf("clearOperationAnnotationAndStatus() status = %q, want %q", stored.Status, models.PipelineStatusRunning)
+	}
+}
+
+func TestClearOperationAnnotationAndStatusPreservesStartTimeWhenNotRequested(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r, p := newOperationTestReconcilerWithPipeline(t, map[string]string{
+		constants.PipelineTerminateAnnotation:          "true",
+		constants.PipelineOperationStartTimeAnnotation: "2026-03-16T12:00:00Z",
+	})
+
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		logr.Discard(),
+		&p,
+		constants.PipelineTerminateAnnotation,
+		models.PipelineStatusStopped,
+		false,
+	)
+
+	stored := getPipelineForOperationTest(t, r, p.Name, p.Namespace)
+	if _, exists := stored.Annotations[constants.PipelineTerminateAnnotation]; exists {
+		t.Fatalf("clearOperationAnnotationAndStatus() did not remove terminate annotation")
+	}
+	if _, exists := stored.Annotations[constants.PipelineOperationStartTimeAnnotation]; !exists {
+		t.Fatalf("clearOperationAnnotationAndStatus() unexpectedly removed operation start time")
+	}
+	if stored.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusStopped) {
+		t.Fatalf("clearOperationAnnotationAndStatus() status = %q, want %q", stored.Status, models.PipelineStatusStopped)
+	}
+}
+
+func TestClearOperationAnnotationAndStatusNoAnnotationsNoop(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	r, p := newOperationTestReconcilerWithPipeline(t, nil)
+
+	r.clearOperationAnnotationAndStatus(
+		ctx,
+		logr.Discard(),
+		&p,
+		constants.PipelineEditAnnotation,
+		models.PipelineStatusRunning,
+		true,
+	)
+
+	stored := getPipelineForOperationTest(t, r, p.Name, p.Namespace)
+	if stored.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusCreated) {
+		t.Fatalf("clearOperationAnnotationAndStatus() unexpectedly changed status for nil annotations")
+	}
+}
+
+func TestClearOperationAnnotationAndStatusHandlesUpdateError(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{
+		Client: &operationTestClient{
+			objects: map[types.NamespacedName]*etlv1alpha1.Pipeline{},
+		},
+	}
+
+	p := etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "missing-pipeline",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineStopAnnotation: "true",
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "missing-pipeline-id",
+		},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusStopping),
+	}
+
+	r.clearOperationAnnotationAndStatus(
+		context.Background(),
+		logr.Discard(),
+		&p,
+		constants.PipelineStopAnnotation,
+		models.PipelineStatusStopped,
+		true,
+	)
+
+	if _, exists := p.GetAnnotations()[constants.PipelineStopAnnotation]; exists {
+		t.Fatalf("clearOperationAnnotationAndStatus() did not remove local annotation on update error")
+	}
+	if p.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusStopped) {
+		t.Fatalf("clearOperationAnnotationAndStatus() did not set local status on update error")
+	}
+}
+
+func TestCheckOperationTimeoutAndLogProgressNoTimeout(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{}
+	p := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipeline",
+			Namespace: "default",
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipeline-id",
+		},
+	}
+
+	result, handled, err := r.checkOperationTimeoutAndLogProgress(context.Background(), logr.Discard(), p)
+	if err != nil {
+		t.Fatalf("checkOperationTimeoutAndLogProgress() returned error: %v", err)
+	}
+	if handled {
+		t.Fatalf("checkOperationTimeoutAndLogProgress() unexpectedly handled timeout")
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("checkOperationTimeoutAndLogProgress() returned unexpected result: %#v", result)
+	}
+}
+
+func TestRecordOperationSuccessNoopWhenObserversDisabled(t *testing.T) {
+	t.Parallel()
+
+	r := &PipelineReconciler{}
+	r.recordOperationSuccess(context.Background(), "create", "create", "pipeline-id")
+}
+
+func newOperationTestReconcilerWithPipeline(t *testing.T, annotations map[string]string) (*PipelineReconciler, etlv1alpha1.Pipeline) {
+	t.Helper()
+
+	pipeline := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "pipeline-test",
+			Namespace:   "default",
+			Annotations: annotations,
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipeline-test-id",
+		},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusCreated),
+	}
+
+	c := &operationTestClient{
+		objects: map[types.NamespacedName]*etlv1alpha1.Pipeline{
+			{Name: pipeline.Name, Namespace: pipeline.Namespace}: pipeline.DeepCopy(),
+		},
+	}
+
+	r := &PipelineReconciler{
+		Client: c,
+	}
+
+	loaded := getPipelineForOperationTest(t, r, pipeline.Name, pipeline.Namespace)
+	return r, *loaded
+}
+
+func getPipelineForOperationTest(t *testing.T, r *PipelineReconciler, name, namespace string) *etlv1alpha1.Pipeline {
+	t.Helper()
+
+	var pipeline etlv1alpha1.Pipeline
+	if err := r.Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &pipeline); err != nil {
+		t.Fatalf("failed to get pipeline: %v", err)
+	}
+	return &pipeline
+}
+
+type operationTestClient struct {
+	client.Client
+	mu      sync.Mutex
+	objects map[types.NamespacedName]*etlv1alpha1.Pipeline
+}
+
+func (c *operationTestClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	pipeline, ok := obj.(*etlv1alpha1.Pipeline)
+	if !ok {
+		return fmt.Errorf("unsupported object type %T", obj)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	if !exists {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
+	}
+
+	*pipeline = *stored.DeepCopy()
+	return nil
+}
+
+func (c *operationTestClient) Update(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+	pipeline, ok := obj.(*etlv1alpha1.Pipeline)
+	if !ok {
+		return fmt.Errorf("unsupported object type %T", obj)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}
+	if _, exists := c.objects[key]; !exists {
+		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
+	}
+
+	c.objects[key] = pipeline.DeepCopy()
+	return nil
+}

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -35,7 +35,6 @@ func TestOperationHandlerForKnownOperations(t *testing.T) {
 	}
 
 	for _, operation := range operations {
-		operation := operation
 		t.Run(operation, func(t *testing.T) {
 			t.Parallel()
 			handler := r.operationHandlerFor(operation)


### PR DESCRIPTION
Changes:
1. Create operation handler
2. Extract duplicate code into methods for annotation and status cleanup 