### PR TITLE
fix(ETL-869): align NATS subject names with stream names

### DIFF
--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -184,7 +184,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 				{Name: "GLASSFLOW_NATS_SERVER", Value: r.Config.NATS.ComponentAddr},
 				{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 				{Name: "GLASSFLOW_INGESTOR_TOPIC", Value: t.TopicName},
-				{Name: "NATS_SUBJECT_PREFIX", Value: outputBinding.SubjectPrefix},
+				{Name: "NATS_SUBJECT_PREFIX", Value: outputBinding.Prefix},
 				{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Ingestor},
 
 				{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.Config.Observability.LogsEnabled},
@@ -304,7 +304,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 			{Name: "NATS_LEFT_INPUT_STREAM_PREFIX", Value: joinInputs.Left.Streams[0].Name},
 			{Name: "NATS_RIGHT_INPUT_STREAM_PREFIX", Value: joinInputs.Right.Streams[0].Name},
-			{Name: "NATS_SUBJECT_PREFIX", Value: joinOutput.SubjectPrefix},
+			{Name: "NATS_SUBJECT_PREFIX", Value: joinOutput.Prefix},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Join},
 
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.Config.Observability.LogsEnabled},
@@ -406,7 +406,7 @@ func (r *PipelineReconciler) createSink(ctx context.Context, ns v1.Namespace, la
 		withEnv(append(append(append([]v1.EnvVar{
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.Config.NATS.ComponentAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
-			{Name: "NATS_INPUT_STREAM_PREFIX", Value: sinkInput.StreamPrefix},
+			{Name: "NATS_INPUT_STREAM_PREFIX", Value: sinkInput.Prefix},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Sink},
 
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.Config.Observability.LogsEnabled},
@@ -545,8 +545,8 @@ func (r *PipelineReconciler) createDedups(ctx context.Context, _ logr.Logger, ns
 			}},
 		}
 		dedupEnvBase = append(dedupEnvBase,
-			v1.EnvVar{Name: "NATS_INPUT_STREAM_PREFIX", Value: dedupInput.StreamPrefix},
-			v1.EnvVar{Name: "NATS_SUBJECT_PREFIX", Value: dedupOutput.SubjectPrefix},
+			v1.EnvVar{Name: "NATS_INPUT_STREAM_PREFIX", Value: dedupInput.Prefix},
+			v1.EnvVar{Name: "NATS_SUBJECT_PREFIX", Value: dedupOutput.Prefix},
 		)
 		dedupContainerBuilder := newComponentContainerBuilder().
 			withName(resourceRef).

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -60,13 +60,13 @@ func TestBuildNATSResourcePlanJoinless(t *testing.T) {
 	wantStreams := []nats.StreamConfig{
 		{
 			Name:     fmt.Sprintf("gfm-%s-ingestor-out_0", hash),
-			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out.0", hash)},
+			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out_0.0", hash)},
 			MaxAge:   5 * time.Minute,
 			MaxBytes: 42,
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-ingestor-out_1", hash),
-			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out.1", hash)},
+			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out_1.1", hash)},
 			MaxAge:   5 * time.Minute,
 			MaxBytes: 42,
 		},
@@ -126,31 +126,31 @@ func TestBuildNATSResourcePlanJoinWithKVStores(t *testing.T) {
 		{
 			Name: fmt.Sprintf("gfm-%s-ingestor_left-out_0", hash),
 			Subjects: []string{
-				fmt.Sprintf("gfm-%s-ingestor_left-out.0", hash),
-				fmt.Sprintf("gfm-%s-ingestor_left-out.1", hash),
+				fmt.Sprintf("gfm-%s-ingestor_left-out_0.0", hash),
+				fmt.Sprintf("gfm-%s-ingestor_left-out_0.1", hash),
 			},
 		},
 		{
 			Name: fmt.Sprintf("gfm-%s-ingestor_right-out_0", hash),
 			Subjects: []string{
-				fmt.Sprintf("gfm-%s-ingestor_right-out.0", hash),
-				fmt.Sprintf("gfm-%s-ingestor_right-out.2", hash),
+				fmt.Sprintf("gfm-%s-ingestor_right-out_0.0", hash),
+				fmt.Sprintf("gfm-%s-ingestor_right-out_0.2", hash),
 			},
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-ingestor_right-out_1", hash),
-			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor_right-out.1", hash)},
+			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor_right-out_1.1", hash)},
 		},
 		{
 			Name: fmt.Sprintf("gfm-%s-dedup_right-out_0", hash),
 			Subjects: []string{
-				fmt.Sprintf("gfm-%s-dedup_right-out.0", hash),
-				fmt.Sprintf("gfm-%s-dedup_right-out.1", hash),
+				fmt.Sprintf("gfm-%s-dedup_right-out_0.0", hash),
+				fmt.Sprintf("gfm-%s-dedup_right-out_0.1", hash),
 			},
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-join-out_0", hash),
-			Subjects: []string{fmt.Sprintf("gfm-%s-join-out.0", hash)},
+			Subjects: []string{fmt.Sprintf("gfm-%s-join-out_0.0", hash)},
 		},
 	}
 	if !reflect.DeepEqual(plan.Streams, wantStreams) {

--- a/internal/pipelinegraph/graph.go
+++ b/internal/pipelinegraph/graph.go
@@ -255,7 +255,7 @@ func buildStreams(prefix string, sourceReplicas, streamCount int) []StreamBindin
 	}
 	for r := range sourceReplicas {
 		s := &streams[r%streamCount]
-		s.Subjects = append(s.Subjects, prefix+"."+strconv.Itoa(r))
+		s.Subjects = append(s.Subjects, s.Name+"."+strconv.Itoa(r))
 	}
 	return streams
 }

--- a/internal/pipelinegraph/graph.go
+++ b/internal/pipelinegraph/graph.go
@@ -142,8 +142,8 @@ func (g *Graph) getInputByType(nodeID string, inputType InputType) (InputBinding
 	}
 
 	return InputBinding{
-		StreamPrefix: output.StreamPrefix,
-		Streams:      output.Streams,
+		Prefix:  output.Prefix,
+		Streams: output.Streams,
 	}, nil
 }
 
@@ -235,9 +235,8 @@ func (g *Graph) resolveOutput(edge EdgeConfig) (OutputBinding, error) {
 	}
 
 	return OutputBinding{
-		StreamPrefix:  basePrefix,
-		SubjectPrefix: basePrefix,
-		Streams:       buildStreams(basePrefix, source.Replicas, target.Replicas),
+		Prefix:  basePrefix,
+		Streams: buildStreams(basePrefix, source.Replicas, target.Replicas),
 	}, nil
 }
 

--- a/internal/pipelinegraph/graph_test.go
+++ b/internal/pipelinegraph/graph_test.go
@@ -14,15 +14,14 @@ func streamBinding(name string, subjects ...string) StreamBinding {
 
 func outputBinding(prefix string, streams ...StreamBinding) OutputBinding {
 	return OutputBinding{
-		StreamPrefix:  prefix,
-		SubjectPrefix: prefix,
-		Streams:       streams,
+		Prefix:  prefix,
+		Streams: streams,
 	}
 }
 
 func inputBinding(prefix string, streams ...StreamBinding) InputBinding {
 	return InputBinding{
-		StreamPrefix: prefix,
+		Prefix:  prefix,
 		Streams:      streams,
 	}
 }
@@ -386,7 +385,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetInput(dedup_0) returned error: %v", err)
 	}
-	wantDedup0Input := inputBinding(wantIngestor0Output.StreamPrefix, wantIngestor0Output.Streams...)
+	wantDedup0Input := inputBinding(wantIngestor0Output.Prefix, wantIngestor0Output.Streams...)
 	if !reflect.DeepEqual(dedup0Input, wantDedup0Input) {
 		t.Fatalf("dedup0Input = %#v, want %#v", dedup0Input, wantDedup0Input)
 	}
@@ -425,7 +424,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetInput(dedup_1) returned error: %v", err)
 	}
-	wantDedup1Input := inputBinding(wantIngestor1Output.StreamPrefix, wantIngestor1Output.Streams...)
+	wantDedup1Input := inputBinding(wantIngestor1Output.Prefix, wantIngestor1Output.Streams...)
 	if !reflect.DeepEqual(dedup1Input, wantDedup1Input) {
 		t.Fatalf("dedup1Input = %#v, want %#v", dedup1Input, wantDedup1Input)
 	}
@@ -452,8 +451,8 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 		t.Fatalf("GetJoinInput(join_0) returned error: %v", err)
 	}
 	wantJoinInput := JoinInputBinding{
-		Left:  inputBinding(wantDedup0Output.StreamPrefix, wantDedup0Output.Streams...),
-		Right: inputBinding(wantDedup1Output.StreamPrefix, wantDedup1Output.Streams...),
+		Left:  inputBinding(wantDedup0Output.Prefix, wantDedup0Output.Streams...),
+		Right: inputBinding(wantDedup1Output.Prefix, wantDedup1Output.Streams...),
 	}
 	if !reflect.DeepEqual(joinInput, wantJoinInput) {
 		t.Fatalf("joinInput = %#v, want %#v", joinInput, wantJoinInput)
@@ -475,7 +474,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetInput(sink_0) returned error: %v", err)
 	}
-	wantSinkInput := inputBinding(wantJoinOutput.StreamPrefix, wantJoinOutput.Streams...)
+	wantSinkInput := inputBinding(wantJoinOutput.Prefix, wantJoinOutput.Streams...)
 	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
 		t.Fatalf("sinkInput = %#v, want %#v", sinkInput, wantSinkInput)
 	}

--- a/internal/pipelinegraph/graph_test.go
+++ b/internal/pipelinegraph/graph_test.go
@@ -69,8 +69,8 @@ func TestGraphIngestorSinkTwoTwo(t *testing.T) {
 
 	wantOutput := outputBinding(
 		"gfm-1528386a-ingestor_0-out",
-		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
-		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out_0.0"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(output, wantOutput) {
 		t.Fatalf("output = %#v, want %#v", output, wantOutput)
@@ -82,8 +82,8 @@ func TestGraphIngestorSinkTwoTwo(t *testing.T) {
 	}
 	wantSinkInput := inputBinding(
 		"gfm-1528386a-ingestor_0-out",
-		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
-		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out_0.0"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
 		t.Fatalf("sinkInput = %#v, want %#v", sinkInput, wantSinkInput)
@@ -133,9 +133,9 @@ func TestGraphTwoIngestorsJoinSink(t *testing.T) {
 		"gfm-2802cd7f-ingestor_0-out",
 		streamBinding(
 			"gfm-2802cd7f-ingestor_0-out_0",
-			"gfm-2802cd7f-ingestor_0-out.0",
-			"gfm-2802cd7f-ingestor_0-out.1",
-			"gfm-2802cd7f-ingestor_0-out.2",
+			"gfm-2802cd7f-ingestor_0-out_0.0",
+			"gfm-2802cd7f-ingestor_0-out_0.1",
+			"gfm-2802cd7f-ingestor_0-out_0.2",
 		),
 	)
 	if !reflect.DeepEqual(left, wantLeft) {
@@ -147,8 +147,8 @@ func TestGraphTwoIngestorsJoinSink(t *testing.T) {
 		"gfm-2802cd7f-ingestor_1-out",
 		streamBinding(
 			"gfm-2802cd7f-ingestor_1-out_0",
-			"gfm-2802cd7f-ingestor_1-out.0",
-			"gfm-2802cd7f-ingestor_1-out.1",
+			"gfm-2802cd7f-ingestor_1-out_0.0",
+			"gfm-2802cd7f-ingestor_1-out_0.1",
 		),
 	)
 	if !reflect.DeepEqual(right, wantRight) {
@@ -161,7 +161,7 @@ func TestGraphTwoIngestorsJoinSink(t *testing.T) {
 	}
 	wantJoinOutput := outputBinding(
 		"gfm-2802cd7f-join_0-out",
-		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out.0"),
+		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out_0.0"),
 	)
 	if !reflect.DeepEqual(joinOutput, wantJoinOutput) {
 		t.Fatalf("joinOutput = %#v, want %#v", joinOutput, wantJoinOutput)
@@ -173,7 +173,7 @@ func TestGraphTwoIngestorsJoinSink(t *testing.T) {
 	}
 	wantSinkInput := inputBinding(
 		"gfm-2802cd7f-join_0-out",
-		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out.0"),
+		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out_0.0"),
 	)
 	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
 		t.Fatalf("sinkInput = %#v, want %#v", sinkInput, wantSinkInput)
@@ -211,8 +211,8 @@ func TestGraphDedupOutputNamingTwoTwo(t *testing.T) {
 
 	wantOutput := outputBinding(
 		"gfm-1528386a-dedup_0-out",
-		streamBinding("gfm-1528386a-dedup_0-out_0", "gfm-1528386a-dedup_0-out.0"),
-		streamBinding("gfm-1528386a-dedup_0-out_1", "gfm-1528386a-dedup_0-out.1"),
+		streamBinding("gfm-1528386a-dedup_0-out_0", "gfm-1528386a-dedup_0-out_0.0"),
+		streamBinding("gfm-1528386a-dedup_0-out_1", "gfm-1528386a-dedup_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(output, wantOutput) {
 		t.Fatalf("output = %#v, want %#v", output, wantOutput)
@@ -274,10 +274,10 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 		"gfm-1528386a-ingestor_0-out",
 		streamBinding(
 			"gfm-1528386a-ingestor_0-out_0",
-			"gfm-1528386a-ingestor_0-out.0",
-			"gfm-1528386a-ingestor_0-out.2",
+			"gfm-1528386a-ingestor_0-out_0.0",
+			"gfm-1528386a-ingestor_0-out_0.2",
 		),
-		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(ingestorOutput, wantIngestorOutput) {
 		t.Fatalf("ingestorOutput = %#v, want %#v", ingestorOutput, wantIngestorOutput)
@@ -291,10 +291,10 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 		"gfm-1528386a-ingestor_0-out",
 		streamBinding(
 			"gfm-1528386a-ingestor_0-out_0",
-			"gfm-1528386a-ingestor_0-out.0",
-			"gfm-1528386a-ingestor_0-out.2",
+			"gfm-1528386a-ingestor_0-out_0.0",
+			"gfm-1528386a-ingestor_0-out_0.2",
 		),
-		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(dedupInput, wantDedupInput) {
 		t.Fatalf("dedupInput = %#v, want %#v", dedupInput, wantDedupInput)
@@ -308,8 +308,8 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 		"gfm-1528386a-dedup_0-out",
 		streamBinding(
 			"gfm-1528386a-dedup_0-out_0",
-			"gfm-1528386a-dedup_0-out.0",
-			"gfm-1528386a-dedup_0-out.1",
+			"gfm-1528386a-dedup_0-out_0.0",
+			"gfm-1528386a-dedup_0-out_0.1",
 		),
 	)
 	if !reflect.DeepEqual(dedupOutput, wantDedupOutput) {
@@ -324,8 +324,8 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 		"gfm-1528386a-dedup_0-out",
 		streamBinding(
 			"gfm-1528386a-dedup_0-out_0",
-			"gfm-1528386a-dedup_0-out.0",
-			"gfm-1528386a-dedup_0-out.1",
+			"gfm-1528386a-dedup_0-out_0.0",
+			"gfm-1528386a-dedup_0-out_0.1",
 		),
 	)
 	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
@@ -375,8 +375,8 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantIngestor0Output := outputBinding(
 		"gfm-2802cd7f-ingestor_0-out",
-		streamBinding("gfm-2802cd7f-ingestor_0-out_0", "gfm-2802cd7f-ingestor_0-out.0"),
-		streamBinding("gfm-2802cd7f-ingestor_0-out_1", "gfm-2802cd7f-ingestor_0-out.1"),
+		streamBinding("gfm-2802cd7f-ingestor_0-out_0", "gfm-2802cd7f-ingestor_0-out_0.0"),
+		streamBinding("gfm-2802cd7f-ingestor_0-out_1", "gfm-2802cd7f-ingestor_0-out_1.1"),
 	)
 	if !reflect.DeepEqual(ingestor0Output, wantIngestor0Output) {
 		t.Fatalf("ingestor0Output = %#v, want %#v", ingestor0Output, wantIngestor0Output)
@@ -399,8 +399,8 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 		"gfm-2802cd7f-dedup_0-out",
 		streamBinding(
 			"gfm-2802cd7f-dedup_0-out_0",
-			"gfm-2802cd7f-dedup_0-out.0",
-			"gfm-2802cd7f-dedup_0-out.1",
+			"gfm-2802cd7f-dedup_0-out_0.0",
+			"gfm-2802cd7f-dedup_0-out_0.1",
 		),
 	)
 	if !reflect.DeepEqual(dedup0Output, wantDedup0Output) {
@@ -413,9 +413,9 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantIngestor1Output := outputBinding(
 		"gfm-2802cd7f-ingestor_1-out",
-		streamBinding("gfm-2802cd7f-ingestor_1-out_0", "gfm-2802cd7f-ingestor_1-out.0"),
-		streamBinding("gfm-2802cd7f-ingestor_1-out_1", "gfm-2802cd7f-ingestor_1-out.1"),
-		streamBinding("gfm-2802cd7f-ingestor_1-out_2", "gfm-2802cd7f-ingestor_1-out.2"),
+		streamBinding("gfm-2802cd7f-ingestor_1-out_0", "gfm-2802cd7f-ingestor_1-out_0.0"),
+		streamBinding("gfm-2802cd7f-ingestor_1-out_1", "gfm-2802cd7f-ingestor_1-out_1.1"),
+		streamBinding("gfm-2802cd7f-ingestor_1-out_2", "gfm-2802cd7f-ingestor_1-out_2.2"),
 	)
 	if !reflect.DeepEqual(ingestor1Output, wantIngestor1Output) {
 		t.Fatalf("ingestor1Output = %#v, want %#v", ingestor1Output, wantIngestor1Output)
@@ -438,9 +438,9 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 		"gfm-2802cd7f-dedup_1-out",
 		streamBinding(
 			"gfm-2802cd7f-dedup_1-out_0",
-			"gfm-2802cd7f-dedup_1-out.0",
-			"gfm-2802cd7f-dedup_1-out.1",
-			"gfm-2802cd7f-dedup_1-out.2",
+			"gfm-2802cd7f-dedup_1-out_0.0",
+			"gfm-2802cd7f-dedup_1-out_0.1",
+			"gfm-2802cd7f-dedup_1-out_0.2",
 		),
 	)
 	if !reflect.DeepEqual(dedup1Output, wantDedup1Output) {
@@ -465,7 +465,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantJoinOutput := outputBinding(
 		"gfm-2802cd7f-join_0-out",
-		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out.0"),
+		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out_0.0"),
 	)
 	if !reflect.DeepEqual(joinOutput, wantJoinOutput) {
 		t.Fatalf("joinOutput = %#v, want %#v", joinOutput, wantJoinOutput)

--- a/internal/pipelinegraph/types.go
+++ b/internal/pipelinegraph/types.go
@@ -46,14 +46,13 @@ type StreamBinding struct {
 }
 
 type OutputBinding struct {
-	StreamPrefix  string          `json:"stream_prefix"`
-	SubjectPrefix string          `json:"subject_prefix"`
-	Streams       []StreamBinding `json:"streams"`
+	Prefix  string          `json:"prefix"`
+	Streams []StreamBinding `json:"streams"`
 }
 
 type InputBinding struct {
-	StreamPrefix string          `json:"stream_prefix"`
-	Streams      []StreamBinding `json:"streams"`
+	Prefix  string          `json:"prefix"`
+	Streams []StreamBinding `json:"streams"`
 }
 
 type JoinInputBinding struct {


### PR DESCRIPTION
## Summary
- Stream names use `prefix_N` (underscore) but subjects were using `prefix.N` (dot), causing wildcard filter `prefix_N.*` to never match any subject
- Fix `buildStreams` in `pipelinegraph/graph.go` to derive subjects from the stream name (`prefix_N.r`) rather than the base prefix (`prefix.r`)
- Update all related test expectations in `graph_test.go` and `nats_resource_plan_test.go`
