### PR TITLE
ETL-914: if stop triggered by component add reason for notification

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -23,6 +23,10 @@ const (
 	// during a stop operation, used to detect whether messages are being consumed.
 	PipelineStopLastPendingCountAnnotation = "pipeline.etl.glassflow.io/stop-last-pending-count"
 
+	// PipelineStopReasonAnnotation stores the reason a pipeline was stopped (e.g. from a component signal).
+	// If absent, the stop was triggered via API.
+	PipelineStopReasonAnnotation = "pipeline.etl.glassflow.io/stop-reason"
+
 	// DefaultReconcileTimeout is the default maximum duration a reconcile operation can run before timing out
 	DefaultReconcileTimeout = 15 * time.Minute
 

--- a/internal/consumers/component_signals_consumer.go
+++ b/internal/consumers/component_signals_consumer.go
@@ -159,6 +159,10 @@ func (c *ComponentSignalsConsumer) stopPipeline(ctx context.Context, message mod
 
 	// Add stop annotation
 	annotations[constants.PipelineStopAnnotation] = "true"
+	// Persist the reason from the component signal so the controller can include it in the stop notification.
+	if message.Text != "" {
+		annotations[constants.PipelineStopReasonAnnotation] = message.Text
+	}
 	pipeline.SetAnnotations(annotations)
 
 	// Update the resource with the stop annotation

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -243,7 +243,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "create", "create", pipelineID, "")
+	r.recordOperationSuccess(ctx, "create", pipelineID, "")
 
 	log.Info("pipeline creation completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -292,7 +292,7 @@ func (r *PipelineReconciler) reconcileTerminate(ctx context.Context, log logr.Lo
 		models.PipelineStatusStopped,
 		false,
 	)
-	r.recordOperationSuccess(ctx, "terminate", "terminate", pipelineID, "")
+	r.recordOperationSuccess(ctx, "terminate", pipelineID, "")
 
 	log.Info("pipeline termination completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -366,7 +366,7 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	r.recordOperationSuccess(ctx, "delete", "delete", pipelineID, "")
+	r.recordOperationSuccess(ctx, "delete", pipelineID, "")
 
 	log.Info("pipeline deletion completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -463,7 +463,7 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	r.recordOperationSuccess(ctx, "uninstall", "helm-uninstall", pipelineID, "")
+	r.recordOperationSuccess(ctx, "helm-uninstall", pipelineID, "")
 
 	log.Info("pipeline helm uninstall completed successfully - FORCE CLEANUP", "pipeline", p.Name, "pipeline_id", pipelineID)
 	return ctrl.Result{}, nil
@@ -566,7 +566,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "resume", "resume", pipelineID, "")
+	r.recordOperationSuccess(ctx, "resume", pipelineID, "")
 
 	log.Info("pipeline resume completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -659,7 +659,7 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		models.PipelineStatusStopped,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "stop", "stop", pipelineID, stopMessage)
+	r.recordOperationSuccess(ctx, "stop", pipelineID, stopMessage)
 
 	log.Info("pipeline stop completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -742,7 +742,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "edit", "edit", pipelineID, "")
+	r.recordOperationSuccess(ctx, "edit", pipelineID, "")
 
 	log.Info("pipeline edit completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -243,7 +243,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "create", "create", pipelineID)
+	r.recordOperationSuccess(ctx, "create", "create", pipelineID, "")
 
 	log.Info("pipeline creation completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -292,7 +292,7 @@ func (r *PipelineReconciler) reconcileTerminate(ctx context.Context, log logr.Lo
 		models.PipelineStatusStopped,
 		false,
 	)
-	r.recordOperationSuccess(ctx, "terminate", "terminate", pipelineID)
+	r.recordOperationSuccess(ctx, "terminate", "terminate", pipelineID, "")
 
 	log.Info("pipeline termination completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -366,7 +366,7 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	r.recordOperationSuccess(ctx, "delete", "delete", pipelineID)
+	r.recordOperationSuccess(ctx, "delete", "delete", pipelineID, "")
 
 	log.Info("pipeline deletion completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -463,7 +463,7 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 		return ctrl.Result{}, fmt.Errorf("delete pipeline CRD: %w", err)
 	}
 
-	r.recordOperationSuccess(ctx, "uninstall", "helm-uninstall", pipelineID)
+	r.recordOperationSuccess(ctx, "uninstall", "helm-uninstall", pipelineID, "")
 
 	log.Info("pipeline helm uninstall completed successfully - FORCE CLEANUP", "pipeline", p.Name, "pipeline_id", pipelineID)
 	return ctrl.Result{}, nil
@@ -566,7 +566,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "resume", "resume", pipelineID)
+	r.recordOperationSuccess(ctx, "resume", "resume", pipelineID, "")
 
 	log.Info("pipeline resume completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -641,6 +641,15 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to stopped: %w", err)
 	}
 
+	// Read stop reason before clearing annotations. A non-empty value means the stop was
+	// triggered by a component signal; absence means the stop was requested via the API.
+	stopMessage := "Pipeline stopped by user via API"
+	if annotations := p.GetAnnotations(); annotations != nil {
+		if reason, ok := annotations[constants.PipelineStopReasonAnnotation]; ok && reason != "" {
+			stopMessage = reason
+		}
+	}
+
 	r.clearStopLastPendingCount(&p)
 	r.clearOperationAnnotationAndStatus(
 		ctx,
@@ -650,7 +659,7 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		models.PipelineStatusStopped,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "stop", "stop", pipelineID)
+	r.recordOperationSuccess(ctx, "stop", "stop", pipelineID, stopMessage)
 
 	log.Info("pipeline stop completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil
@@ -733,7 +742,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		models.PipelineStatusRunning,
 		true,
 	)
-	r.recordOperationSuccess(ctx, "edit", "edit", pipelineID)
+	r.recordOperationSuccess(ctx, "edit", "edit", pipelineID, "")
 
 	log.Info("pipeline edit completed successfully", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 	return ctrl.Result{}, nil

--- a/internal/controller/notifications.go
+++ b/internal/controller/notifications.go
@@ -25,13 +25,13 @@ func (r *PipelineReconciler) failureNotificationMetadata(operation string, err e
 	}
 }
 
-func (r *PipelineReconciler) sendOperationSuccessNotification(ctx context.Context, operation, pipelineID string) {
+func (r *PipelineReconciler) sendOperationSuccessNotification(ctx context.Context, operation, pipelineID, message string) {
 	if !notifications.IsEnabled() {
 		return
 	}
 
 	metadata := r.successNotificationMetadata(operation)
-	notification := buildOperationSuccessNotification(operation, pipelineID, metadata)
+	notification := buildOperationSuccessNotification(operation, pipelineID, message, metadata)
 	if notification == nil {
 		return
 	}
@@ -42,6 +42,7 @@ func (r *PipelineReconciler) sendOperationSuccessNotification(ctx context.Contex
 func buildOperationSuccessNotification(
 	operation string,
 	pipelineID string,
+	message string,
 	metadata map[string]interface{},
 ) *notifications.Notification {
 
@@ -51,7 +52,7 @@ func buildOperationSuccessNotification(
 	case constants.OperationResume:
 		return notifications.NewPipelineResumedNotification(pipelineID, "", "", metadata)
 	case constants.OperationStop:
-		return notifications.NewPipelineStoppedNotification(pipelineID, "", "", metadata)
+		return notifications.NewPipelineStoppedNotification(pipelineID, "", message, metadata)
 	case constants.OperationTerminate:
 		return notifications.NewPipelineStoppedNotification(
 			pipelineID,

--- a/internal/controller/notifications_test.go
+++ b/internal/controller/notifications_test.go
@@ -72,7 +72,7 @@ func TestBuildOperationSuccessNotification(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildOperationSuccessNotification(tt.operation, pipelineID, metadata)
+			got := buildOperationSuccessNotification(tt.operation, pipelineID, "", metadata)
 			if got == nil {
 				t.Fatalf("notification is nil")
 			}
@@ -93,7 +93,7 @@ func TestBuildOperationSuccessNotification(t *testing.T) {
 }
 
 func TestBuildOperationSuccessNotificationUnknownOperation(t *testing.T) {
-	got := buildOperationSuccessNotification("unknown", "pipeline-123", nil)
+	got := buildOperationSuccessNotification("unknown", "pipeline-123", "", nil)
 	if got != nil {
 		t.Fatalf("expected nil notification for unknown operation")
 	}

--- a/internal/controller/operations.go
+++ b/internal/controller/operations.go
@@ -98,12 +98,13 @@ func (r *PipelineReconciler) recordOperationSuccess(
 	metricsOperation string,
 	usageStatsOperation string,
 	pipelineID string,
+	message string,
 ) {
 	r.recordMetricsIfEnabled(func(m *observability.Meter) {
 		m.RecordReconcileOperation(ctx, metricsOperation, "success", pipelineID)
 	})
 	r.sendReconcileSuccessEvent(ctx, usageStatsOperation, pipelineID)
-	r.sendOperationSuccessNotification(ctx, usageStatsOperation, pipelineID)
+	r.sendOperationSuccessNotification(ctx, usageStatsOperation, pipelineID, message)
 }
 
 func defaultOperationRequeueResult() ctrl.Result {

--- a/internal/controller/operations.go
+++ b/internal/controller/operations.go
@@ -95,16 +95,15 @@ func (r *PipelineReconciler) clearOperationAnnotationAndStatus(
 
 func (r *PipelineReconciler) recordOperationSuccess(
 	ctx context.Context,
-	metricsOperation string,
-	usageStatsOperation string,
+	operation string,
 	pipelineID string,
 	message string,
 ) {
 	r.recordMetricsIfEnabled(func(m *observability.Meter) {
-		m.RecordReconcileOperation(ctx, metricsOperation, "success", pipelineID)
+		m.RecordReconcileOperation(ctx, operation, "success", pipelineID)
 	})
-	r.sendReconcileSuccessEvent(ctx, usageStatsOperation, pipelineID)
-	r.sendOperationSuccessNotification(ctx, usageStatsOperation, pipelineID, message)
+	r.sendReconcileSuccessEvent(ctx, operation, pipelineID)
+	r.sendOperationSuccessNotification(ctx, operation, pipelineID, message)
 }
 
 func defaultOperationRequeueResult() ctrl.Result {

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -284,7 +284,7 @@ func TestRecordOperationSuccessNoopWhenObserversDisabled(t *testing.T) {
 	t.Parallel()
 
 	r := &PipelineReconciler{}
-	r.recordOperationSuccess(context.Background(), "create", "create", "pipeline-id", "")
+	r.recordOperationSuccess(context.Background(), "create", "pipeline-id", "")
 }
 
 func newOperationTestReconcilerWithPipeline(t *testing.T, annotations map[string]string) (*PipelineReconciler, etlv1alpha1.Pipeline) {

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -284,7 +284,7 @@ func TestRecordOperationSuccessNoopWhenObserversDisabled(t *testing.T) {
 	t.Parallel()
 
 	r := &PipelineReconciler{}
-	r.recordOperationSuccess(context.Background(), "create", "create", "pipeline-id")
+	r.recordOperationSuccess(context.Background(), "create", "create", "pipeline-id", "")
 }
 
 func newOperationTestReconcilerWithPipeline(t *testing.T, annotations map[string]string) (*PipelineReconciler, etlv1alpha1.Pipeline) {


### PR DESCRIPTION
1. When component-signals consumer stops pipeline, added annotation for reason a pipeline was stopped, this will be propagated to the notification sent to user
2. Refactored notification callsites to collapse unnecessary arg