### PR TITLE
fix: ensure pipeline deletion completes before postgres is uninstalled (ETL-736)

### DIFF
--- a/charts/glassflow-operator/Chart.yaml
+++ b/charts/glassflow-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.9
+version: 0.7.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/glassflow-operator/templates/pre-delete-hook.yaml
+++ b/charts/glassflow-operator/templates/pre-delete-hook.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-weight": "-100"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "helm.sh/hook-timeout": "600"  # 10 minutes timeout
   labels:
@@ -37,57 +37,90 @@ spec:
         - |
           set -e
           echo "Starting Helm pre-delete hook for GlassFlow operator..."
-          
+
           # Function to annotate all pipelines with helm-uninstall annotation
           annotate_pipelines() {
             echo "Looking for existing Pipeline CRDs..."
-            
-            # Get all Pipeline CRDs
-            PIPELINES=$(kubectl get pipelines.etl.glassflow.io --all-namespaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
-            
-            if [ -z "$PIPELINES" ]; then
+
+            # Check if CRD exists first; if not, there is nothing to annotate
+            if ! kubectl get crd pipelines.etl.glassflow.io > /dev/null 2>&1; then
+              echo "Pipeline CRD definition does not exist. Nothing to terminate."
+              return 0
+            fi
+
+            # Get all Pipeline CRDs with their namespaces
+            if ! kubectl get pipelines.etl.glassflow.io --all-namespaces \
+                -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+                > /tmp/pipeline_list 2>/dev/null; then
+              echo "Warning: Failed to list Pipeline CRDs"
+              return 1
+            fi
+
+            if [ ! -s /tmp/pipeline_list ]; then
               echo "No Pipeline CRDs found. Nothing to terminate."
               return 0
             fi
-            
-            echo "Found Pipeline CRDs: $PIPELINES"
-            
+
+            echo "Found Pipeline CRDs, annotating for helm uninstall..."
+
             # Annotate each pipeline with helm-uninstall annotation
-            for pipeline in $PIPELINES; do
-              echo "Annotating pipeline: $pipeline"
-              kubectl annotate pipeline.etl.glassflow.io "$pipeline" pipeline.etl.glassflow.io/helm-uninstall="true" --overwrite || {
-                echo "Warning: Failed to annotate pipeline $pipeline"
+            # Use the pipeline's actual namespace to ensure the annotation is applied correctly
+            while IFS= read -r line; do
+              [ -z "$line" ] && continue
+              ns=$(echo "$line" | awk '{print $1}')
+              name=$(echo "$line" | awk '{print $2}')
+              echo "Annotating pipeline: $name in namespace: $ns"
+              kubectl annotate pipeline.etl.glassflow.io "$name" -n "$ns" \
+                pipeline.etl.glassflow.io/helm-uninstall="true" --overwrite || {
+                echo "Warning: Failed to annotate pipeline $name in namespace $ns"
               }
-            done
-            
+            done < /tmp/pipeline_list
+
             echo "All pipelines annotated for helm uninstall"
           }
-          
+
           # Function to wait for pipelines to be terminated (BLOCKS until complete)
           wait_for_termination() {
             echo "Waiting for all pipelines to be terminated..."
             local max_attempts=60  # 10 minutes with 10 second intervals
             local attempt=0
-            
+
             while [ $attempt -lt $max_attempts ]; do
-              # Check if any pipelines still exist
-              REMAINING_PIPELINES=$(kubectl get pipelines.etl.glassflow.io --all-namespaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
-              
+              # If the CRD definition itself no longer exists, all instances are gone
+              if ! kubectl get crd pipelines.etl.glassflow.io > /dev/null 2>&1; then
+                echo "Pipeline CRD definition no longer exists - all pipelines terminated"
+                return 0
+              fi
+
+              # Check if any pipelines still exist; treat kubectl errors as transient
+              # (do NOT treat a failed kubectl call as "no pipelines" to avoid a false positive
+              #  that would allow Helm to delete PostgreSQL before pipeline cleanup completes)
+              if ! kubectl get pipelines.etl.glassflow.io --all-namespaces \
+                  -o jsonpath='{.items[*].metadata.name}' \
+                  > /tmp/remaining_pipelines 2>/dev/null; then
+                echo "Warning: Failed to list pipelines, retrying..."
+                sleep 10
+                attempt=$((attempt + 1))
+                continue
+              fi
+
+              REMAINING_PIPELINES=$(cat /tmp/remaining_pipelines)
+
               if [ -z "$REMAINING_PIPELINES" ]; then
                 echo "All pipelines terminated successfully"
                 return 0
               fi
-              
+
               echo "Waiting for pipelines to terminate: $REMAINING_PIPELINES"
               sleep 10
               attempt=$((attempt + 1))
             done
-            
+
             echo "TIMEOUT: Some pipelines were not terminated within the timeout period"
             echo "Remaining pipelines: $REMAINING_PIPELINES"
             return 1
           }
-          
+
           # Function to delete CRD definition
           delete_crd_definition() {
             echo "Deleting Pipeline CRD definition..."
@@ -96,51 +129,54 @@ spec:
             }
             echo "Pipeline CRD definition deletion attempted"
           }
-          
+
           # Function to add finalizer to operator deployment to prevent deletion
+          # while pipeline cleanup is in progress.
           protect_operator_deployment() {
             echo "Protecting operator deployment from premature shutdown..."
-            
+
             local operator_deployment_name="{{ .Release.Name }}-controller-manager"
             local operator_namespace="{{ .Release.Namespace }}"
             local operator_deployment="deployment/$operator_deployment_name"
-            
+
             kubectl patch "$operator_deployment" -n "$operator_namespace" --type=merge -p='{"metadata":{"finalizers":["helm-pre-delete-hook.glassflow.io/cleanup"]}}' || {
               echo "Warning: Failed to add finalizer to operator deployment"
             }
           }
-          
+
           # Function to remove finalizer from operator deployment
           unprotect_operator_deployment() {
             echo "Removing finalizer from operator deployment to allow shutdown..."
-            
+
             local operator_deployment_name="{{ .Release.Name }}-controller-manager"
             local operator_namespace="{{ .Release.Namespace }}"
             local operator_deployment="deployment/$operator_deployment_name"
-            
+
             kubectl patch "$operator_deployment" -n "$operator_namespace" --type=merge -p='{"metadata":{"finalizers":[]}}' || {
               echo "Warning: Failed to remove finalizer from operator deployment"
             }
           }
-          
+
           # Main execution
           echo "=== Helm Pre-Delete Hook Started ==="
-          
+
           # Step 1: Protect operator deployment from deletion
           protect_operator_deployment
-          
+
           # Step 2: Annotate all pipelines for termination
           annotate_pipelines
-          
+
           # Step 3: Wait for operator to terminate all pipelines (BLOCKS here)
+          # The operator deletes pipeline data from PostgreSQL before removing the pipeline
+          # CRD finalizer, so all pipelines disappearing guarantees PostgreSQL is clean.
           wait_for_termination
-          
+
           # Step 4: Remove protection from operator deployment
           unprotect_operator_deployment
-          
+
           # Step 5: Delete the CRD definition
           delete_crd_definition
-          
+
           echo "=== Helm Pre-Delete Hook Completed ==="
         resources:
           requests:


### PR DESCRIPTION
## Summary

Fixes ETL-736: Three bugs in the pre-delete hook allowed postgres to be deleted before pipeline cleanup could finish.

- **False positive in `wait_for_termination`**: `kubectl get pipelines ... 2>/dev/null || echo ""` swallowed kubectl errors silently, making the hook believe all pipelines were gone and exit early. Helm would then proceed to delete postgres while the operator was still mid-cleanup. Fixed by treating `kubectl` failures as transient and retrying rather than treating them as "no pipelines".

- **Missing namespace in `kubectl annotate`**: Pipeline CRDs are namespace-scoped but the annotate command omitted `-n <namespace>`, so pipelines in a namespace other than the hook pod's default namespace were silently skipped and never cleaned up. Fixed by extracting the namespace from the pipeline list and passing it explicitly to each `kubectl annotate` call.

- **Hook weight `-10` races with same-weight postgres hooks**: Helm runs same-weight pre-delete hooks in parallel. If a postgres chart also registers a pre-delete hook at weight `-10`, postgres could be terminated while our pipeline cleanup hook was still waiting. Changed weight to `-100` so this hook always completes before any postgres pre-delete hooks start.

Also bumps chart version to `0.7.10`.

## Test plan

- [ ] `helm uninstall` with active pipelines: verify all pipeline CRDs and postgres records are cleaned up before postgres pod is terminated
- [ ] `helm uninstall` with no pipelines: verify hook exits immediately without errors
- [ ] Simulate transient kubectl API error during uninstall: verify hook retries rather than exiting with false success
- [ ] Verify pipeline in a non-default namespace is correctly annotated and cleaned up