### PR TITLE
ETL-856: Enable scaling of downstream pipeline components

### DIFF
--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -290,8 +290,8 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 		withEnv(append(append(append([]v1.EnvVar{
 			{Name: "GLASSFLOW_NATS_SERVER", Value: r.Config.NATS.ComponentAddr},
 			{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
-			{Name: "NATS_LEFT_INPUT_STREAM_PREFIX", Value: joinInputs.Left.Streams[0].Name},
-			{Name: "NATS_RIGHT_INPUT_STREAM_PREFIX", Value: joinInputs.Right.Streams[0].Name},
+			{Name: "NATS_LEFT_INPUT_STREAM_PREFIX", Value: joinInputs.Left.StreamPrefix},
+			{Name: "NATS_RIGHT_INPUT_STREAM_PREFIX", Value: joinInputs.Right.StreamPrefix},
 			{Name: "NATS_SUBJECT_PREFIX", Value: joinOutput.SubjectPrefix},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Join},
 

--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -122,28 +122,24 @@ func buildJoinNodePlan(
 		return natsNodePlan{}, fmt.Errorf("resolve join inputs for node %s: %w", node.ID, err)
 	}
 
-	leftStore, err := inputBindingStoreName(inputs.Left)
-	if err != nil {
-		return natsNodePlan{}, fmt.Errorf("resolve left join input store name: %w", err)
+	if len(inputs.Left.Streams) == 0 {
+		return natsNodePlan{}, fmt.Errorf("left join input has no streams")
+	}
+	if len(inputs.Right.Streams) == 0 {
+		return natsNodePlan{}, fmt.Errorf("right join input has no streams")
 	}
 
-	rightStore, err := inputBindingStoreName(inputs.Right)
-	if err != nil {
-		return natsNodePlan{}, fmt.Errorf("resolve right join input store name: %w", err)
+	kvStores := make([]natsJoinKVStorePlan, 0, len(inputs.Left.Streams)+len(inputs.Right.Streams))
+	for _, s := range inputs.Left.Streams {
+		kvStores = append(kvStores, natsJoinKVStorePlan{Name: s.Name, TTL: join.LeftBufferTTL})
+	}
+	for _, s := range inputs.Right.Streams {
+		kvStores = append(kvStores, natsJoinKVStorePlan{Name: s.Name, TTL: join.RightBufferTTL})
 	}
 
 	return natsNodePlan{
-		Streams: producerPlan.Streams,
-		JoinKVStores: []natsJoinKVStorePlan{
-			{
-				Name: leftStore,
-				TTL:  join.LeftBufferTTL,
-			},
-			{
-				Name: rightStore,
-				TTL:  join.RightBufferTTL,
-			},
-		},
+		Streams:      producerPlan.Streams,
+		JoinKVStores: kvStores,
 	}, nil
 }
 
@@ -162,12 +158,4 @@ func buildOutputStreams(
 		})
 	}
 	return streams
-}
-
-func inputBindingStoreName(binding pipelinegraph.InputBinding) (string, error) {
-	if len(binding.Streams) == 0 {
-		return "", fmt.Errorf("input binding has no streams")
-	}
-
-	return binding.Streams[0].Name, nil
 }

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -172,6 +172,55 @@ func TestBuildNATSResourcePlanJoinWithKVStores(t *testing.T) {
 	}
 }
 
+func TestBuildNATSResourcePlanJoinWithMultipleReplicas(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{NATSClient: &nats.NATSClient{}}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-join-scaled",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "left"},
+					{TopicName: "right"},
+				},
+			},
+			Join: etlv1alpha1.Join{
+				Enabled:        true,
+				LeftBufferTTL:  time.Minute,
+				RightBufferTTL: 2 * time.Minute,
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Ingestor: &etlv1alpha1.IngestorResources{
+					Left:  &etlv1alpha1.ComponentResources{Replicas: ptrInt32(2)},
+					Right: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(2)},
+				},
+				Join: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(2)},
+				Sink: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(2)},
+			},
+		},
+	}
+
+	plan, err := reconciler.buildNATSResourcePlan(pipeline)
+	if err != nil {
+		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
+	}
+
+	hash := generatePipelineHash(pipeline.Spec.ID)
+	// Each join replica gets its own KV store for left and right inputs.
+	wantJoinKVStores := []natsJoinKVStorePlan{
+		{Name: fmt.Sprintf("gfm-%s-ingestor_left-out_0", hash), TTL: time.Minute},
+		{Name: fmt.Sprintf("gfm-%s-ingestor_left-out_1", hash), TTL: time.Minute},
+		{Name: fmt.Sprintf("gfm-%s-ingestor_right-out_0", hash), TTL: 2 * time.Minute},
+		{Name: fmt.Sprintf("gfm-%s-ingestor_right-out_1", hash), TTL: 2 * time.Minute},
+	}
+	if !reflect.DeepEqual(plan.JoinKVStores, wantJoinKVStores) {
+		t.Fatalf("plan.JoinKVStores = %#v, want %#v", plan.JoinKVStores, wantJoinKVStores)
+	}
+}
+
 func TestBuildNATSResourcePlanOTLPSinkOnly(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Enables join, sink, and dedup components to run with multiple replicas.

- **Operator**: Each join replica now reads from its own dedicated NATS stream, determined by pod index — consistent with how sink and dedup already handle per-replica stream routing. NATS KV stores for join buffering are now created per stream (one per join replica) instead of just for the first stream.
- **Operator**: The `NATS_LEFT_INPUT_STREAM_PREFIX` and `NATS_RIGHT_INPUT_STREAM_PREFIX` env vars now carry the stream _prefix_ (not a specific stream name), so each pod can compute its own stream name using its pod index.

Companion PR in clickhouse-etl removes the API-layer validations that previously rejected join/sink replica counts > 1.

## Changes

**`internal/controller/create_components.go`**
- Pass `StreamPrefix` instead of `Streams[0].Name` for join input stream env vars, enabling each join pod to derive its stream by `{prefix}_{podIndex}`

**`internal/controller/nats_resource_plan.go`**
- Create one NATS KV store per join input stream (one per join replica per side) instead of only for the first stream

**`internal/controller/nats_resource_plan_test.go`**
- Add test covering NATS resource plan for a join pipeline with 2 join replicas, verifying 4 KV stores (2 left + 2 right) are created