### PR TITLE
feat: allow downstream components to have more replicas than upstream

### DIFF
--- a/internal/controller/create_components.go
+++ b/internal/controller/create_components.go
@@ -140,19 +140,12 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 			}
 		}
 
-		subjectCountEnvVars := ingestorNATSSubjectCountEnvVars(t, ingestorReplicas)
-		if t.Deduplication != nil && t.Deduplication.Enabled {
-			replicasForSubjects := ingestorReplicas
-			if replicasForSubjects <= 0 {
-				replicasForSubjects = 1
-			}
-			subjectCountEnvVars = []v1.EnvVar{{Name: "NATS_SUBJECT_COUNT", Value: fmt.Sprintf("%d", replicasForSubjects)}}
-		}
-
 		outputBinding, err := graph.GetOutput(pipelinegraph.IngestorNodeID(p.Spec, i))
 		if err != nil {
 			return fmt.Errorf("resolve ingestor output for stream %d: %w", i, err)
 		}
+
+		subjectCountEnvVars := ingestorNATSSubjectCountEnvVars(t, outputBinding.TotalSubjectCount)
 
 		err = r.createHeadlessService(ctx, ns.GetName(), resourceRef, ingestorLabels)
 		if err != nil {
@@ -173,6 +166,7 @@ func (r *PipelineReconciler) createIngestors(ctx context.Context, _ logr.Logger,
 				{Name: "GLASSFLOW_PIPELINE_CONFIG", Value: "/config/pipeline.json"},
 				{Name: "GLASSFLOW_INGESTOR_TOPIC", Value: t.TopicName},
 				{Name: "NATS_SUBJECT_PREFIX", Value: outputBinding.SubjectPrefix},
+				{Name: "NATS_SUBJECT_TOTAL_COUNT", Value: fmt.Sprintf("%d", outputBinding.TotalSubjectCount)},
 				{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Ingestor},
 
 				{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.Config.Observability.LogsEnabled},
@@ -293,6 +287,7 @@ func (r *PipelineReconciler) createJoin(ctx context.Context, ns v1.Namespace, la
 			{Name: "NATS_LEFT_INPUT_STREAM_PREFIX", Value: joinInputs.Left.Streams[0].Name},
 			{Name: "NATS_RIGHT_INPUT_STREAM_PREFIX", Value: joinInputs.Right.Streams[0].Name},
 			{Name: "NATS_SUBJECT_PREFIX", Value: joinOutput.SubjectPrefix},
+			{Name: "NATS_SUBJECT_TOTAL_COUNT", Value: fmt.Sprintf("%d", joinOutput.TotalSubjectCount)},
 			{Name: "GLASSFLOW_LOG_LEVEL", Value: r.Config.Observability.LogLevels.Join},
 
 			{Name: "GLASSFLOW_OTEL_LOGS_ENABLED", Value: r.Config.Observability.LogsEnabled},
@@ -565,6 +560,7 @@ func (r *PipelineReconciler) createSingleDedup(
 	dedupEnv = append(dedupEnv,
 		v1.EnvVar{Name: "NATS_INPUT_STREAM_PREFIX", Value: dedupInput.StreamPrefix},
 		v1.EnvVar{Name: "NATS_SUBJECT_PREFIX", Value: dedupOutput.SubjectPrefix},
+		v1.EnvVar{Name: "NATS_SUBJECT_TOTAL_COUNT", Value: fmt.Sprintf("%d", dedupOutput.TotalSubjectCount)},
 	)
 
 	containerBuilder := newComponentContainerBuilder().

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -71,15 +71,17 @@ func (r *PipelineReconciler) getDedupLabels(topic string) map[string]string {
 	return labels
 }
 
-// ingestorNATSSubjectCountEnvVars returns NATS_SUBJECT_COUNT=ingestorReplicas when dedup is enabled for the stream.
-func ingestorNATSSubjectCountEnvVars(stream etlv1alpha1.SourceStream, ingestorReplicas int) []v1.EnvVar {
+// ingestorNATSSubjectCountEnvVars returns NATS_SUBJECT_COUNT=totalSubjectCount when dedup is enabled for the stream.
+// totalSubjectCount must be max(ingestorReplicas, downstreamReplicas) so that dedup key hashing covers
+// the full set of subjects the ingestor may publish to.
+func ingestorNATSSubjectCountEnvVars(stream etlv1alpha1.SourceStream, totalSubjectCount int) []v1.EnvVar {
 	if stream.Deduplication == nil || !stream.Deduplication.Enabled {
 		return nil
 	}
-	if ingestorReplicas <= 0 {
-		ingestorReplicas = constants.DefaultMinReplicas
+	if totalSubjectCount <= 0 {
+		totalSubjectCount = constants.DefaultMinReplicas
 	}
-	return []v1.EnvVar{{Name: "NATS_SUBJECT_COUNT", Value: strconv.Itoa(ingestorReplicas)}}
+	return []v1.EnvVar{{Name: "NATS_SUBJECT_COUNT", Value: strconv.Itoa(totalSubjectCount)}}
 }
 
 // preparePipelineLabels returns labels for pipeline resources

--- a/internal/pipelinegraph/graph.go
+++ b/internal/pipelinegraph/graph.go
@@ -235,27 +235,33 @@ func (g *Graph) resolveOutput(edge EdgeConfig) (OutputBinding, error) {
 	}
 
 	return OutputBinding{
-		StreamPrefix:  basePrefix,
-		SubjectPrefix: basePrefix,
-		Streams:       buildStreams(basePrefix, source.Replicas, target.Replicas),
+		StreamPrefix:      basePrefix,
+		SubjectPrefix:     basePrefix,
+		Streams:           buildStreams(basePrefix, source.Replicas, target.Replicas),
+		TotalSubjectCount: max(source.Replicas, target.Replicas),
 	}, nil
 }
 
-// buildStreams assigns subjects to streams round-robin (subject r -> stream r%streamCount).
-// e.g. 3 subjects and 2 streams
-// [subject_0, subject_1, subject_2]
-// [stream_0, stream_1]
-// result:
-// stream_0 = [subject_0, subject_2]
-// stream_1 = [subject_1]
+// buildStreams assigns subjects to streams round-robin (subject s -> stream s%streamCount).
+// Always creates exactly streamCount streams (one per downstream consumer).
+// Total subjects = max(sourceReplicas, streamCount), so when downstream > upstream,
+// the upstream replicas are each responsible for multiple subjects (round-robin publish).
+//
+// e.g. 1 source replica, 2 streams (1 ingestor → 2 sinks):
+// subjects: [0, 1] -> stream_0=[subject_0], stream_1=[subject_1]
+// source pod 0 publishes to both subjects round-robin.
+//
+// e.g. 3 source replicas, 2 streams:
+// subjects: [0, 1, 2] -> stream_0=[subject_0, subject_2], stream_1=[subject_1]
+// each source pod publishes to its own subject.
 func buildStreams(prefix string, sourceReplicas, streamCount int) []StreamBinding {
-	streams := make([]StreamBinding, min(sourceReplicas, streamCount))
+	totalSubjects := max(sourceReplicas, streamCount)
+	streams := make([]StreamBinding, streamCount)
 	for i := range streams {
 		streams[i].Name = fmt.Sprintf("%s_%d", prefix, i)
 	}
-	for r := range sourceReplicas {
-		s := &streams[r%streamCount]
-		s.Subjects = append(s.Subjects, prefix+"."+strconv.Itoa(r))
+	for s := range totalSubjects {
+		streams[s%streamCount].Subjects = append(streams[s%streamCount].Subjects, prefix+"."+strconv.Itoa(s))
 	}
 	return streams
 }

--- a/internal/pipelinegraph/graph.go
+++ b/internal/pipelinegraph/graph.go
@@ -234,11 +234,16 @@ func (g *Graph) resolveOutput(edge EdgeConfig) (OutputBinding, error) {
 		return OutputBinding{}, err
 	}
 
+	streams := buildStreams(basePrefix, source.Replicas, target.Replicas)
+	totalSubjects := 0
+	for _, s := range streams {
+		totalSubjects += len(s.Subjects)
+	}
 	return OutputBinding{
 		StreamPrefix:      basePrefix,
 		SubjectPrefix:     basePrefix,
-		Streams:           buildStreams(basePrefix, source.Replicas, target.Replicas),
-		TotalSubjectCount: max(source.Replicas, target.Replicas),
+		Streams:           streams,
+		TotalSubjectCount: totalSubjects,
 	}, nil
 }
 

--- a/internal/pipelinegraph/graph_test.go
+++ b/internal/pipelinegraph/graph_test.go
@@ -12,11 +12,12 @@ func streamBinding(name string, subjects ...string) StreamBinding {
 	}
 }
 
-func outputBinding(prefix string, streams ...StreamBinding) OutputBinding {
+func outputBinding(prefix string, totalSubjectCount int, streams ...StreamBinding) OutputBinding {
 	return OutputBinding{
-		StreamPrefix:  prefix,
-		SubjectPrefix: prefix,
-		Streams:       streams,
+		StreamPrefix:      prefix,
+		SubjectPrefix:     prefix,
+		Streams:           streams,
+		TotalSubjectCount: totalSubjectCount,
 	}
 }
 
@@ -69,6 +70,7 @@ func TestGraphIngestorSinkTwoTwo(t *testing.T) {
 
 	wantOutput := outputBinding(
 		"gfm-1528386a-ingestor_0-out",
+		2,
 		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
 		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
 	)
@@ -161,6 +163,7 @@ func TestGraphTwoIngestorsJoinSink(t *testing.T) {
 	}
 	wantJoinOutput := outputBinding(
 		"gfm-2802cd7f-join_0-out",
+		1,
 		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out.0"),
 	)
 	if !reflect.DeepEqual(joinOutput, wantJoinOutput) {
@@ -211,6 +214,7 @@ func TestGraphDedupOutputNamingTwoTwo(t *testing.T) {
 
 	wantOutput := outputBinding(
 		"gfm-1528386a-dedup_0-out",
+		2,
 		streamBinding("gfm-1528386a-dedup_0-out_0", "gfm-1528386a-dedup_0-out.0"),
 		streamBinding("gfm-1528386a-dedup_0-out_1", "gfm-1528386a-dedup_0-out.1"),
 	)
@@ -272,6 +276,7 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 	}
 	wantIngestorOutput := outputBinding(
 		"gfm-1528386a-ingestor_0-out",
+		3,
 		streamBinding(
 			"gfm-1528386a-ingestor_0-out_0",
 			"gfm-1528386a-ingestor_0-out.0",
@@ -306,6 +311,7 @@ func TestGraphIngestorDedupSinkThreeTwoOne(t *testing.T) {
 	}
 	wantDedupOutput := outputBinding(
 		"gfm-1528386a-dedup_0-out",
+		2,
 		streamBinding(
 			"gfm-1528386a-dedup_0-out_0",
 			"gfm-1528386a-dedup_0-out.0",
@@ -375,6 +381,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantIngestor0Output := outputBinding(
 		"gfm-2802cd7f-ingestor_0-out",
+		2,
 		streamBinding("gfm-2802cd7f-ingestor_0-out_0", "gfm-2802cd7f-ingestor_0-out.0"),
 		streamBinding("gfm-2802cd7f-ingestor_0-out_1", "gfm-2802cd7f-ingestor_0-out.1"),
 	)
@@ -397,6 +404,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantDedup0Output := outputBinding(
 		"gfm-2802cd7f-dedup_0-out",
+		2,
 		streamBinding(
 			"gfm-2802cd7f-dedup_0-out_0",
 			"gfm-2802cd7f-dedup_0-out.0",
@@ -413,6 +421,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantIngestor1Output := outputBinding(
 		"gfm-2802cd7f-ingestor_1-out",
+		3,
 		streamBinding("gfm-2802cd7f-ingestor_1-out_0", "gfm-2802cd7f-ingestor_1-out.0"),
 		streamBinding("gfm-2802cd7f-ingestor_1-out_1", "gfm-2802cd7f-ingestor_1-out.1"),
 		streamBinding("gfm-2802cd7f-ingestor_1-out_2", "gfm-2802cd7f-ingestor_1-out.2"),
@@ -436,6 +445,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantDedup1Output := outputBinding(
 		"gfm-2802cd7f-dedup_1-out",
+		3,
 		streamBinding(
 			"gfm-2802cd7f-dedup_1-out_0",
 			"gfm-2802cd7f-dedup_1-out.0",
@@ -465,6 +475,7 @@ func TestGraphTwoIngestorsTwoDedupsJoinSink(t *testing.T) {
 	}
 	wantJoinOutput := outputBinding(
 		"gfm-2802cd7f-join_0-out",
+		1,
 		streamBinding("gfm-2802cd7f-join_0-out_0", "gfm-2802cd7f-join_0-out.0"),
 	)
 	if !reflect.DeepEqual(joinOutput, wantJoinOutput) {
@@ -509,6 +520,7 @@ func TestGraphOTLPSourceSink(t *testing.T) {
 	}
 	wantOTLPOutput := outputBinding(
 		"gfm-1528386a-otlp-out",
+		1,
 		streamBinding("gfm-1528386a-otlp-out_0", "gfm-1528386a-otlp-out.0"),
 	)
 	if !reflect.DeepEqual(otlpOutput, wantOTLPOutput) {
@@ -553,9 +565,12 @@ func TestGraphOTLPSourceDedupSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOutput(otlp) returned error: %v", err)
 	}
+	// otlp(1) → dedup(2): new algorithm creates 2 streams (one per downstream consumer)
 	wantOTLPOutput := outputBinding(
 		"gfm-1528386a-otlp-out",
+		2,
 		streamBinding("gfm-1528386a-otlp-out_0", "gfm-1528386a-otlp-out.0"),
+		streamBinding("gfm-1528386a-otlp-out_1", "gfm-1528386a-otlp-out.1"),
 	)
 	if !reflect.DeepEqual(otlpOutput, wantOTLPOutput) {
 		t.Fatalf("otlpOutput = %#v, want %#v", otlpOutput, wantOTLPOutput)
@@ -576,6 +591,7 @@ func TestGraphOTLPSourceDedupSink(t *testing.T) {
 	}
 	wantDedupOutput := outputBinding(
 		"gfm-1528386a-dedup_0-out",
+		2,
 		streamBinding(
 			"gfm-1528386a-dedup_0-out_0",
 			"gfm-1528386a-dedup_0-out.0",
@@ -593,6 +609,109 @@ func TestGraphOTLPSourceDedupSink(t *testing.T) {
 	wantSinkInput := inputBinding(wantDedupOutput.StreamPrefix, wantDedupOutput.Streams...)
 	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
 		t.Fatalf("sinkInput = %#v, want %#v", sinkInput, wantSinkInput)
+	}
+}
+
+// Topology:
+//
+//	┌───────────────┐         ┌───────────┐
+//	│ ingestor_0 x1 ├── in ──►│ sink_0 x2 │
+//	└───────────────┘         └───────────┘
+//
+// When upstream has fewer replicas than downstream, the new algorithm creates
+// streamCount streams and totalSubjects=max(source,stream) subjects.
+// The single ingestor pod publishes to subjects 0 and 1 round-robin.
+func TestGraphIngestorSinkOneTwo(t *testing.T) {
+	t.Parallel()
+
+	graph, err := New(Config{
+		PipelineID: "pipe-1",
+		Nodes: []NodeConfig{
+			{ID: "ingestor_0", Type: NodeTypeIngestor, Replicas: 1},
+			{ID: "sink_0", Type: NodeTypeSink, Replicas: 2},
+		},
+		Edges: []EdgeConfig{
+			{ID: "e1", SourceID: "ingestor_0", TargetID: "sink_0", TargetInputType: InputTypeIn},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	output, err := graph.GetOutput("ingestor_0")
+	if err != nil {
+		t.Fatalf("GetOutput returned error: %v", err)
+	}
+
+	// 2 streams created (one per sink replica), 2 subjects total (max(1,2)=2).
+	// Ingestor pod 0 is responsible for both subjects (round-robin publish).
+	wantOutput := outputBinding(
+		"gfm-1528386a-ingestor_0-out",
+		2,
+		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+	)
+	if !reflect.DeepEqual(output, wantOutput) {
+		t.Fatalf("output = %#v, want %#v", output, wantOutput)
+	}
+
+	sinkInput, err := graph.GetInput("sink_0")
+	if err != nil {
+		t.Fatalf("GetInput(sink_0) returned error: %v", err)
+	}
+	wantSinkInput := inputBinding(
+		"gfm-1528386a-ingestor_0-out",
+		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+	)
+	if !reflect.DeepEqual(sinkInput, wantSinkInput) {
+		t.Fatalf("sinkInput = %#v, want %#v", sinkInput, wantSinkInput)
+	}
+}
+
+// Topology:
+//
+//	┌───────────────┐         ┌───────────┐
+//	│ ingestor_0 x2 ├── in ──►│ sink_0 x5 │
+//	└───────────────┘         └───────────┘
+//
+// 5 streams created, 5 subjects total (max(2,5)=5).
+// Pod 0 handles subjects 0, 2, 4 (even indices); pod 1 handles 1, 3 (odd).
+func TestGraphIngestorSinkTwoFive(t *testing.T) {
+	t.Parallel()
+
+	graph, err := New(Config{
+		PipelineID: "pipe-1",
+		Nodes: []NodeConfig{
+			{ID: "ingestor_0", Type: NodeTypeIngestor, Replicas: 2},
+			{ID: "sink_0", Type: NodeTypeSink, Replicas: 5},
+		},
+		Edges: []EdgeConfig{
+			{ID: "e1", SourceID: "ingestor_0", TargetID: "sink_0", TargetInputType: InputTypeIn},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	output, err := graph.GetOutput("ingestor_0")
+	if err != nil {
+		t.Fatalf("GetOutput returned error: %v", err)
+	}
+
+	// 5 streams, 5 subjects (max(2,5)=5); each stream gets exactly one subject.
+	// Pod 0 publishes to subjects 0,2,4 (s%2==0); pod 1 to subjects 1,3 (s%2==1).
+	wantOutput := outputBinding(
+		"gfm-1528386a-ingestor_0-out",
+		5,
+		streamBinding("gfm-1528386a-ingestor_0-out_0", "gfm-1528386a-ingestor_0-out.0"),
+		streamBinding("gfm-1528386a-ingestor_0-out_1", "gfm-1528386a-ingestor_0-out.1"),
+		streamBinding("gfm-1528386a-ingestor_0-out_2", "gfm-1528386a-ingestor_0-out.2"),
+		streamBinding("gfm-1528386a-ingestor_0-out_3", "gfm-1528386a-ingestor_0-out.3"),
+		streamBinding("gfm-1528386a-ingestor_0-out_4", "gfm-1528386a-ingestor_0-out.4"),
+	)
+	if !reflect.DeepEqual(output, wantOutput) {
+		t.Fatalf("output = %#v, want %#v", output, wantOutput)
 	}
 }
 

--- a/internal/pipelinegraph/types.go
+++ b/internal/pipelinegraph/types.go
@@ -47,9 +47,10 @@ type StreamBinding struct {
 }
 
 type OutputBinding struct {
-	StreamPrefix  string          `json:"stream_prefix"`
-	SubjectPrefix string          `json:"subject_prefix"`
-	Streams       []StreamBinding `json:"streams"`
+	StreamPrefix      string          `json:"stream_prefix"`
+	SubjectPrefix     string          `json:"subject_prefix"`
+	Streams           []StreamBinding `json:"streams"`
+	TotalSubjectCount int             `json:"total_subject_count"`
 }
 
 type InputBinding struct {


### PR DESCRIPTION
## Summary

- `buildStreams()` now creates `max(sourceReplicas, downstreamReplicas)` subjects and distributes them round-robin across `downstreamReplicas` streams, so every sink always gets exactly one stream with at least one subject
- `TotalSubjectCount` added to `OutputBinding` and injected as `NATS_SUBJECT_TOTAL_COUNT` into ingestor, dedup, and join components
- Removes the hard `source >= downstream` replica constraint from the graph layer

## Test plan

- [X] `go test ./internal/pipelinegraph/...` — new tests for 1→2 and 2→5 asymmetric cases
- [X] Deploy with 1 ingestor + 2 sinks, verify both sinks receive data
- [X] Verify existing pipelines with equal replicas are unaffected


Tested on DEV