### PR TITLE
ETL-957: Do not stop OTLP pipeline input streams

### DIFF
--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -204,6 +204,13 @@ func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha
 		m.RecordNATSOperation(ctx, "create_dlq_stream", "success", p.Spec.ID)
 	})
 
+	for _, stream := range plan.OTLPSourceStreams {
+		err = r.NATSClient.CreateOrUpdateStream(ctx, stream)
+		if err != nil {
+			return fmt.Errorf("create stream %s: %w", stream.Name, err)
+		}
+	}
+
 	for _, stream := range plan.Streams {
 		err = r.NATSClient.CreateOrUpdateStream(ctx, stream)
 		if err != nil {
@@ -221,21 +228,33 @@ func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha
 	return nil
 }
 
+type natsCleanupOptions struct {
+	deleteDLQ       bool
+	keepOTLPStreams bool
+}
+
 // cleanupNATSPipelineResources cleans up all NATS resources for a pipeline, including DLQ.
 func (r *PipelineReconciler) cleanupNATSPipelineResources(ctx context.Context, log logr.Logger, p etlv1alpha1.Pipeline) error {
-	return r.cleanupNATSPipelineResourcesWithDLQOption(ctx, log, p, true)
+	return r.cleanupNATSPipelineResourcesWithOptions(ctx, log, p, natsCleanupOptions{
+		deleteDLQ:       true,
+		keepOTLPStreams: false,
+	})
 }
 
-// cleanupNATSPipelineResourcesKeepDLQ cleans up pipeline NATS resources while preserving DLQ.
+// cleanupNATSPipelineResourcesKeepDLQ cleans up pipeline NATS resources while preserving DLQ
+// and OTLP source streams (so the shared OTLP receiver can continue buffering events).
 func (r *PipelineReconciler) cleanupNATSPipelineResourcesKeepDLQ(ctx context.Context, log logr.Logger, p etlv1alpha1.Pipeline) error {
-	return r.cleanupNATSPipelineResourcesWithDLQOption(ctx, log, p, false)
+	return r.cleanupNATSPipelineResourcesWithOptions(ctx, log, p, natsCleanupOptions{
+		deleteDLQ:       false,
+		keepOTLPStreams: true,
+	})
 }
 
-func (r *PipelineReconciler) cleanupNATSPipelineResourcesWithDLQOption(
+func (r *PipelineReconciler) cleanupNATSPipelineResourcesWithOptions(
 	ctx context.Context,
 	log logr.Logger,
 	p etlv1alpha1.Pipeline,
-	deleteDLQ bool,
+	opts natsCleanupOptions,
 ) error {
 	log.Info("cleaning up NATS streams", "pipeline", p.Name, "pipeline_id", p.Spec.ID)
 
@@ -249,7 +268,7 @@ func (r *PipelineReconciler) cleanupNATSPipelineResourcesWithDLQOption(
 		return fmt.Errorf("build NATS resource plan: %w", err)
 	}
 
-	if deleteDLQ {
+	if opts.deleteDLQ {
 		// delete the DLQ stream
 		log.Info("deleting NATS DLQ stream", "stream", plan.DLQStream.Name)
 		err = r.deleteNATSStream(ctx, log, plan.DLQStream.Name)
@@ -266,6 +285,19 @@ func (r *PipelineReconciler) cleanupNATSPipelineResourcesWithDLQOption(
 		log.Info("NATS DLQ stream deleted successfully", "stream", plan.DLQStream.Name)
 	} else {
 		log.Info("skipping NATS DLQ stream cleanup", "pipeline_id", p.Spec.ID)
+	}
+
+	if opts.keepOTLPStreams && len(plan.OTLPSourceStreams) > 0 {
+		for _, stream := range plan.OTLPSourceStreams {
+			log.Info("preserving OTLP source stream during stop", "stream", stream.Name, "pipeline_id", p.Spec.ID)
+		}
+	} else {
+		for _, stream := range plan.OTLPSourceStreams {
+			err = r.deleteNATSStream(ctx, log, stream.Name)
+			if err != nil {
+				return fmt.Errorf("delete OTLP source stream %s: %w", stream.Name, err)
+			}
+		}
 	}
 
 	for _, kvStore := range plan.JoinKVStores {

--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -15,9 +15,10 @@ type natsJoinKVStorePlan struct {
 }
 
 type natsResourcePlan struct {
-	DLQStream    nats.StreamConfig
-	Streams      []nats.StreamConfig
-	JoinKVStores []natsJoinKVStorePlan
+	DLQStream         nats.StreamConfig
+	Streams           []nats.StreamConfig
+	OTLPSourceStreams []nats.StreamConfig
+	JoinKVStores      []natsJoinKVStorePlan
 }
 
 type natsNodePlan struct {
@@ -82,7 +83,11 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 			return natsResourcePlan{}, err
 		}
 
-		plan.Streams = append(plan.Streams, nodePlan.Streams...)
+		if node.Type == pipelinegraph.NodeTypeOTLPSource {
+			plan.OTLPSourceStreams = append(plan.OTLPSourceStreams, nodePlan.Streams...)
+		} else {
+			plan.Streams = append(plan.Streams, nodePlan.Streams...)
+		}
 		plan.JoinKVStores = append(plan.JoinKVStores, nodePlan.JoinKVStores...)
 	}
 

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -192,14 +192,17 @@ func TestBuildNATSResourcePlanOTLPSinkOnly(t *testing.T) {
 	}
 
 	hash := generatePipelineHash(pipeline.Spec.ID)
-	wantStreams := []nats.StreamConfig{
+	wantOTLPStreams := []nats.StreamConfig{
 		{
 			Name:     fmt.Sprintf("gfm-%s-otlp-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-otlp-out.0", hash)},
 		},
 	}
-	if !reflect.DeepEqual(plan.Streams, wantStreams) {
-		t.Fatalf("plan.Streams = %#v, want %#v", plan.Streams, wantStreams)
+	if !reflect.DeepEqual(plan.OTLPSourceStreams, wantOTLPStreams) {
+		t.Fatalf("plan.OTLPSourceStreams = %#v, want %#v", plan.OTLPSourceStreams, wantOTLPStreams)
+	}
+	if len(plan.Streams) != 0 {
+		t.Fatalf("plan.Streams = %#v, want none", plan.Streams)
 	}
 	if len(plan.JoinKVStores) != 0 {
 		t.Fatalf("plan.JoinKVStores = %#v, want none", plan.JoinKVStores)
@@ -230,11 +233,16 @@ func TestBuildNATSResourcePlanOTLPWithDedup(t *testing.T) {
 	}
 
 	hash := generatePipelineHash(pipeline.Spec.ID)
-	wantStreams := []nats.StreamConfig{
+	wantOTLPStreams := []nats.StreamConfig{
 		{
 			Name:     fmt.Sprintf("gfm-%s-otlp-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-otlp-out.0", hash)},
 		},
+	}
+	if !reflect.DeepEqual(plan.OTLPSourceStreams, wantOTLPStreams) {
+		t.Fatalf("plan.OTLPSourceStreams = %#v, want %#v", plan.OTLPSourceStreams, wantOTLPStreams)
+	}
+	wantStreams := []nats.StreamConfig{
 		{
 			Name:     fmt.Sprintf("gfm-%s-dedup-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-dedup-out.0", hash)},


### PR DESCRIPTION
# PR: Preserve OTLP source NATS streams on pipeline stop

## Problem

When an OTLP pipeline is stopped, all operation NATS streams are deleted. The shared OTLP receiver keeps running and loses its target stream, silently dropping events until the pipeline is resumed.

## Solution

Keep the OTLP source output stream alive during stop so the receiver can continue buffering events into NATS. Terminate and delete still clean everything.

| Operation | DLQ | OTLP source stream | Other streams |
|-----------|-----|--------------------|---------------|
| Stop      | Keep | **Keep (new)** | Delete |
| Terminate | Delete | Delete | Delete |
| Delete    | Delete | Delete | Delete |

Resume is unchanged — `CreateOrUpdateStream` is idempotent.

## Changes

### `internal/controller/nats_resource_plan.go`

- Added `OTLPSourceStreams` field to `natsResourcePlan`
- OTLP source node streams are now routed to `OTLPSourceStreams` instead of `Streams`

### `internal/controller/nats.go`

- Added `natsCleanupOptions` struct with `deleteDLQ` and `keepOTLPStreams` flags
- `createNATSStreams()` creates both `OTLPSourceStreams` and `Streams`
- Stop path sets `keepOTLPStreams: true`, terminate/delete path sets `false`

### `internal/controller/nats_resource_plan_test.go`

- Updated OTLP test cases to assert streams land in `OTLPSourceStreams`

## Impact

- Kafka pipelines: no change (`OTLPSourceStreams` is empty)
- OTLP pipelines: OTLP source stream preserved on stop, deleted on terminate/delete
