### PR TITLE
ETL-958: Make multiple OTLP pipelines input streams

### DIFF
--- a/internal/pipelinegraph/builder.go
+++ b/internal/pipelinegraph/builder.go
@@ -66,13 +66,18 @@ func ConfigFromOTLPPipelineSpec(spec etlv1alpha1.PipelineSpec) (Config, error) {
 	otlpID := OTLPSourceNodeID()
 	sinkID := SinkNodeID()
 
+	otlpReplicas := getSinkReplicas(spec)
+	if transformsAreEnabled(spec) {
+		otlpReplicas = getDedupReplicas(spec)
+	}
+
 	config := Config{
 		PipelineID: spec.ID,
 		Nodes: []NodeConfig{
 			{
 				ID:       otlpID,
 				Type:     NodeTypeOTLPSource,
-				Replicas: constants.DefaultMinReplicas,
+				Replicas: otlpReplicas,
 			},
 		},
 	}

--- a/internal/pipelinegraph/builder_test.go
+++ b/internal/pipelinegraph/builder_test.go
@@ -164,7 +164,7 @@ func TestConfigFromOTLPPipelineSpecSinkOnly(t *testing.T) {
 	want := Config{
 		PipelineID: "pipe-otlp",
 		Nodes: []NodeConfig{
-			{ID: "otlp", Type: NodeTypeOTLPSource, Replicas: 1},
+			{ID: "otlp", Type: NodeTypeOTLPSource, Replicas: 2},
 			{ID: "sink", Type: NodeTypeSink, Replicas: 2},
 		},
 		Edges: []EdgeConfig{
@@ -200,7 +200,7 @@ func TestConfigFromOTLPPipelineSpecWithDedup(t *testing.T) {
 	want := Config{
 		PipelineID: "pipe-otlp-dedup",
 		Nodes: []NodeConfig{
-			{ID: "otlp", Type: NodeTypeOTLPSource, Replicas: 1},
+			{ID: "otlp", Type: NodeTypeOTLPSource, Replicas: 2},
 			{ID: "dedup", Type: NodeTypeDedup, Replicas: 2},
 			{ID: "sink", Type: NodeTypeSink, Replicas: 1},
 		},


### PR DESCRIPTION
## Fix: OTLP pipelines create only 1 stream regardless of dedup replica count

### Problem

OTLP pipelines with multiple dedup replicas always created only 1 OTLP source stream.
The OTLP source node was hardcoded to `Replicas: 1` in the graph config, and stream
count is `min(sourceReplicas, downstreamReplicas)` — so `min(1, N) = 1` no matter
how many dedup pods were configured.

### Fix

Set the OTLP source node's replica count to match the downstream consumer:
`getDedupReplicas` when transforms are enabled, `getSinkReplicas` otherwise.
This mirrors how ingestor nodes work in regular pipelines.

### Impact

| Pipeline type | Before | After |
|---|---|---|
| OTLP + dedup (N replicas) | 1 OTLP stream | N OTLP streams |
| OTLP + sink only (N replicas) | 1 OTLP stream | N OTLP streams |
| Non-OTLP | no change | no change |