### PR TITLE
ETL-932: Handle otlp streams downscale

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -23,6 +23,11 @@ const (
 	// during a stop operation, used to detect whether messages are being consumed.
 	PipelineStopLastPendingCountAnnotation = "pipeline.etl.glassflow.io/stop-last-pending-count"
 
+	// PipelineEditDrainLastMsgCountAnnotation tracks the last observed total message count across
+	// stale OTLP source streams during an edit-downscale drain, used to detect whether the
+	// NATS Stream Source transfer is making progress before extending the operation timeout.
+	PipelineEditDrainLastMsgCountAnnotation = "pipeline.etl.glassflow.io/edit-drain-last-msg-count"
+
 	// PipelineStopReasonAnnotation stores the reason a pipeline was stopped (e.g. from a component signal).
 	// If absent, the stop was triggered via API.
 	PipelineStopReasonAnnotation = "pipeline.etl.glassflow.io/stop-reason"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,6 +28,11 @@ const (
 	// NATS Stream Source transfer is making progress before extending the operation timeout.
 	PipelineEditDrainLastMsgCountAnnotation = "pipeline.etl.glassflow.io/edit-drain-last-msg-count"
 
+	// PipelineOTLPDownscaleOldSubjectCountAnnotation persists the old OTLP source stream count
+	// across reconcile passes during an edit-downscale, so the subject override stays in effect
+	// even after stale streams have been drained and deleted (and before the edit fully completes).
+	PipelineOTLPDownscaleOldSubjectCountAnnotation = "pipeline.etl.glassflow.io/otlp-downscale-old-subject-count"
+
 	// PipelineStopReasonAnnotation stores the reason a pipeline was stopped (e.g. from a component signal).
 	// If absent, the stop was triggered via API.
 	PipelineStopReasonAnnotation = "pipeline.etl.glassflow.io/stop-reason"

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -673,8 +673,35 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 
 	namespace := r.getTargetNamespace(p)
 
-	if result, handled, err := r.checkOperationTimeoutAndLogProgress(ctx, log, &p); handled || err != nil {
-		return result, err
+	// Discover stale OTLP source streams early — before the timeout check — so that we can use
+	// them to decide whether a timed-out edit should be extended (drain still making progress).
+	var (
+		staleNames      []string
+		oldSubjectCount int
+	)
+	var err error
+	if p.Spec.IsOTLPSource() {
+		staleNames, oldSubjectCount, err = r.discoverStaleStreams(ctx, p)
+		if err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("discover stale streams: %w", err)
+		}
+	}
+
+	// Timeout check — extend if a drain is still making progress (mirrors reconcileStop).
+	timedOut, elapsed := r.checkOperationTimeout(log, &p)
+	if timedOut {
+		if len(staleNames) > 0 {
+			if extended, extErr := r.tryExtendEditDrainTimeout(ctx, log, &p, staleNames); extErr != nil {
+				log.Error(extErr, "failed to check drain progress during edit timeout", "pipeline_id", pipelineID)
+			} else if extended {
+				return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
+			}
+		}
+		return r.handleOperationTimeout(ctx, log, &p)
+	}
+	if elapsed > 0 {
+		log.Info("operation in progress", "pipeline_id", p.Spec.ID, "elapsed", elapsed)
 	}
 
 	// Update the pipeline config secret with new config
@@ -709,22 +736,10 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", namespace, err)
 	}
 
-	// For OTLP pipelines: detect stale source streams left over from a downscale.
-	// On a stopped pipeline only OTLP source streams + DLQ survive, so only those can be stale.
-	var (
-		staleNames      []string
-		oldSubjectCount int
-	)
-	if p.Spec.IsOTLPSource() {
-		staleNames, oldSubjectCount, err = r.discoverStaleStreams(ctx, p)
-		if err != nil {
-			r.recordReconcileError(ctx, "edit", pipelineID, err)
-			return ctrl.Result{}, fmt.Errorf("discover stale streams: %w", err)
-		}
-
+	if p.Spec.IsOTLPSource() && len(staleNames) > 0 {
 		// Dedup downscale protection: stale streams + dedup enabled means dedup replicas
 		// were decreased, which corrupts pod-local Badger state.
-		if len(staleNames) > 0 && p.Spec.Transform.IsDedupEnabled {
+		if p.Spec.Transform.IsDedupEnabled {
 			msg := "dedup replica count cannot be decreased: dedup stores pod-local state"
 			log.Info(msg, "pipeline_id", pipelineID, "stale_streams", staleNames)
 			// Re-fetch to get the latest ResourceVersion — prior Status and annotation
@@ -741,11 +756,10 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		}
 
 		// Unbind subjects from stale streams so active streams can claim them.
-		if len(staleNames) > 0 {
-			if err = r.unbindStaleStreamSubjects(ctx, log, staleNames); err != nil {
-				r.recordReconcileError(ctx, "edit", pipelineID, err)
-				return ctrl.Result{}, fmt.Errorf("unbind stale stream subjects: %w", err)
-			}
+		err = r.unbindStaleStreamSubjects(ctx, log, staleNames)
+		if err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("unbind stale stream subjects: %w", err)
 		}
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -709,10 +709,76 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", namespace, err)
 	}
 
-	err = r.createNATSStreams(ctx, p)
+	// For OTLP pipelines: detect stale source streams left over from a downscale.
+	// On a stopped pipeline only OTLP source streams + DLQ survive, so only those can be stale.
+	var (
+		staleNames      []string
+		oldSubjectCount int
+	)
+	if p.Spec.IsOTLPSource() {
+		staleNames, oldSubjectCount, err = r.discoverStaleStreams(ctx, p)
+		if err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("discover stale streams: %w", err)
+		}
+
+		// Dedup downscale protection: stale streams + dedup enabled means dedup replicas
+		// were decreased, which corrupts pod-local Badger state.
+		if len(staleNames) > 0 && p.Spec.Transform.IsDedupEnabled {
+			msg := "dedup replica count cannot be decreased: dedup stores pod-local state"
+			log.Info(msg, "pipeline_id", pipelineID, "stale_streams", staleNames)
+			// Re-fetch to get the latest ResourceVersion — prior Status and annotation
+			// writes may have bumped it, leaving our local copy stale.
+			err = r.Get(ctx, types.NamespacedName{Name: p.Name, Namespace: p.Namespace}, &p)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("refresh pipeline before status update: %w", err)
+			}
+			err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusFailed, []string{msg})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("update pipeline status: %w", err)
+			}
+			return ctrl.Result{}, nil
+		}
+
+		// Unbind subjects from stale streams so active streams can claim them.
+		if len(staleNames) > 0 {
+			if err = r.unbindStaleStreamSubjects(ctx, log, staleNames); err != nil {
+				r.recordReconcileError(ctx, "edit", pipelineID, err)
+				return ctrl.Result{}, fmt.Errorf("unbind stale stream subjects: %w", err)
+			}
+		}
+	}
+
+	// Build the NATS resource plan, applying subject override when downscaling OTLP streams.
+	// The override redistributes old subjects across new streams so the OTLP receiver's cached
+	// SubjectCount is fully covered — no writes are lost during the gap before it refreshes.
+	natsPlan, err := r.buildNATSResourcePlan(p)
 	if err != nil {
 		r.recordReconcileError(ctx, "edit", pipelineID, err)
+		return ctrl.Result{}, fmt.Errorf("build NATS plan: %w", err)
+	}
+	if len(staleNames) > 0 {
+		overrideOTLPSourceSubjects(&natsPlan, oldSubjectCount)
+		log.Info("applied OTLP subject override for downscale",
+			"old_subject_count", oldSubjectCount,
+			"new_stream_count", len(natsPlan.OTLPSourceStreams))
+	}
+
+	if err = r.createNATSStreamsFromPlan(ctx, p, natsPlan); err != nil {
+		r.recordReconcileError(ctx, "edit", pipelineID, err)
 		return ctrl.Result{}, fmt.Errorf("setup streams: %w", err)
+	}
+
+	// Move messages from stale OTLP source streams to active streams via Stream Sources.
+	if len(staleNames) > 0 {
+		requeue, err := r.reassignStaleStreams(ctx, log, p, staleNames, natsPlan)
+		if err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("reassign stale streams: %w", err)
+		}
+		if requeue {
+			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
+		}
 	}
 
 	// Clean up PVCs for dedup instances that are now disabled.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -686,6 +686,15 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 			r.recordReconcileError(ctx, "edit", pipelineID, err)
 			return ctrl.Result{}, fmt.Errorf("discover stale streams: %w", err)
 		}
+		if len(staleNames) > 0 {
+			// Persist so the subject override survives passes after stale streams are deleted.
+			if persistErr := r.setOTLPDownscaleSubjectCount(ctx, &p, oldSubjectCount); persistErr != nil {
+				log.Error(persistErr, "failed to persist downscale subject count", "pipeline_id", pipelineID)
+			}
+		} else if saved, ok := getOTLPDownscaleSubjectCount(&p); ok {
+			// Stale streams already gone — restore count from the previous pass.
+			oldSubjectCount = saved
+		}
 	}
 
 	// Timeout check — extend if a drain is still making progress (mirrors reconcileStop).
@@ -736,63 +745,24 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("get namespace %s: %w", namespace, err)
 	}
 
-	if p.Spec.IsOTLPSource() && len(staleNames) > 0 {
-		// Dedup downscale protection: stale streams + dedup enabled means dedup replicas
-		// were decreased, which corrupts pod-local Badger state.
-		if p.Spec.Transform.IsDedupEnabled {
-			msg := "dedup replica count cannot be decreased: dedup stores pod-local state"
-			log.Info(msg, "pipeline_id", pipelineID, "stale_streams", staleNames)
-			// Re-fetch to get the latest ResourceVersion — prior Status and annotation
-			// writes may have bumped it, leaving our local copy stale.
-			err = r.Get(ctx, types.NamespacedName{Name: p.Name, Namespace: p.Namespace}, &p)
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("refresh pipeline before status update: %w", err)
-			}
-			err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusFailed, []string{msg})
-			if err != nil {
-				return ctrl.Result{}, fmt.Errorf("update pipeline status: %w", err)
-			}
-			return ctrl.Result{}, nil
+	// Dedup downscale protection: stale streams + dedup enabled means dedup replicas
+	// were decreased, which corrupts pod-local Badger state.
+	if p.Spec.IsOTLPSource() && len(staleNames) > 0 && p.Spec.Transform.IsDedupEnabled {
+		msg := "dedup replica count cannot be decreased: dedup stores pod-local state"
+		log.Info(msg, "pipeline_id", pipelineID, "stale_streams", staleNames)
+		// Re-fetch to get the latest ResourceVersion — prior Status and annotation
+		// writes may have bumped it, leaving our local copy stale.
+		if err = r.Get(ctx, types.NamespacedName{Name: p.Name, Namespace: p.Namespace}, &p); err != nil {
+			return ctrl.Result{}, fmt.Errorf("refresh pipeline before status update: %w", err)
 		}
-
-		// Unbind subjects from stale streams so active streams can claim them.
-		err = r.unbindStaleStreamSubjects(ctx, log, staleNames)
-		if err != nil {
-			r.recordReconcileError(ctx, "edit", pipelineID, err)
-			return ctrl.Result{}, fmt.Errorf("unbind stale stream subjects: %w", err)
+		if err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusFailed, []string{msg}); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update pipeline status: %w", err)
 		}
+		return ctrl.Result{}, nil
 	}
 
-	// Build the NATS resource plan, applying subject override when downscaling OTLP streams.
-	// The override redistributes old subjects across new streams so the OTLP receiver's cached
-	// SubjectCount is fully covered — no writes are lost during the gap before it refreshes.
-	natsPlan, err := r.buildNATSResourcePlan(p)
-	if err != nil {
-		r.recordReconcileError(ctx, "edit", pipelineID, err)
-		return ctrl.Result{}, fmt.Errorf("build NATS plan: %w", err)
-	}
-	if len(staleNames) > 0 {
-		overrideOTLPSourceSubjects(&natsPlan, oldSubjectCount)
-		log.Info("applied OTLP subject override for downscale",
-			"old_subject_count", oldSubjectCount,
-			"new_stream_count", len(natsPlan.OTLPSourceStreams))
-	}
-
-	if err = r.createNATSStreamsFromPlan(ctx, p, natsPlan); err != nil {
-		r.recordReconcileError(ctx, "edit", pipelineID, err)
-		return ctrl.Result{}, fmt.Errorf("setup streams: %w", err)
-	}
-
-	// Move messages from stale OTLP source streams to active streams via Stream Sources.
-	if len(staleNames) > 0 {
-		requeue, err := r.reassignStaleStreams(ctx, log, p, staleNames, natsPlan)
-		if err != nil {
-			r.recordReconcileError(ctx, "edit", pipelineID, err)
-			return ctrl.Result{}, fmt.Errorf("reassign stale streams: %w", err)
-		}
-		if requeue {
-			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
-		}
+	if result, err := r.setupEditNATSStreams(ctx, log, pipelineID, p, staleNames, oldSubjectCount); err != nil || result.Requeue {
+		return result, err
 	}
 
 	// Clean up PVCs for dedup instances that are now disabled.
@@ -821,6 +791,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
 
+	r.clearOTLPDownscaleSubjectCount(&p)
 	r.clearOperationAnnotationAndStatus(
 		ctx,
 		log,

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go/jetstream"
@@ -185,15 +186,147 @@ func (r *PipelineReconciler) checkDedupPendingMessages(ctx context.Context, p et
 	return r.checkInputBindingPendingMessages(ctx, dedupInput, getNATSDedupConsumerName(p.Spec.ID))
 }
 
+// discoverStaleStreams finds NATS streams that belong to this pipeline but are not in the
+// current OTLP source stream plan — orphaned after a downscale. Also returns the old OTLP
+// source stream count (existing streams minus DLQ), needed for subject override.
+// Only meaningful for OTLP pipelines: on a stopped pipeline only OTLP source streams + DLQ survive.
+func (r *PipelineReconciler) discoverStaleStreams(ctx context.Context, p etlv1alpha1.Pipeline) (staleNames []string, oldSubjectCount int, err error) {
+	plan, err := r.buildNATSResourcePlan(p)
+	if err != nil {
+		return nil, 0, fmt.Errorf("build NATS plan for stale detection: %w", err)
+	}
+	hash := generatePipelineHash(p.Spec.ID)
+	existing, err := r.NATSClient.ListPipelineStreams(ctx, hash)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list pipeline streams: %w", err)
+	}
+	stale := staleStreamNames(existing, plan)
+	oldOTLPStreamCount := max(len(existing)-1, 0) // subtract DLQ
+	return stale, oldOTLPStreamCount, nil
+}
+
+// overrideOTLPSourceSubjects redistributes oldSubjectCount subjects round-robin across the
+// OTLP source streams in the plan so the OTLP receiver's cached SubjectCount is fully covered.
+//
+// Example: downscale 3→2, oldSubjectCount=3, new streams=2:
+//
+//	stream_0 gets [.0, .2]  stream_1 gets [.1]
+//
+// The extra binding (.2 on stream_0) becomes idle once the receiver refreshes its config.
+func overrideOTLPSourceSubjects(plan *natsResourcePlan, oldSubjectCount int) {
+	newStreamCount := len(plan.OTLPSourceStreams)
+	if newStreamCount == 0 || oldSubjectCount <= newStreamCount {
+		return
+	}
+	// Extract subject prefix from the first stream's first subject (e.g., "gfm-abc-otlp-out.0" → "gfm-abc-otlp-out")
+	firstSubjects := plan.OTLPSourceStreams[0].Subjects
+	if len(firstSubjects) == 0 {
+		return
+	}
+	dotIdx := strings.LastIndex(firstSubjects[0], ".")
+	if dotIdx < 0 {
+		return
+	}
+	subjectPrefix := firstSubjects[0][:dotIdx]
+
+	for i := range plan.OTLPSourceStreams {
+		plan.OTLPSourceStreams[i].Subjects = nil
+	}
+	for s := range oldSubjectCount {
+		streamIdx := s % newStreamCount
+		plan.OTLPSourceStreams[streamIdx].Subjects = append(
+			plan.OTLPSourceStreams[streamIdx].Subjects,
+			fmt.Sprintf("%s.%d", subjectPrefix, s),
+		)
+	}
+}
+
+// unbindStaleStreamSubjects releases subject ownership from stale streams so that active
+// streams can claim those subjects without NATS subject-overlap errors.
+// Must be called BEFORE createNATSStreamsFromPlan.
+func (r *PipelineReconciler) unbindStaleStreamSubjects(ctx context.Context, log logr.Logger, staleNames []string) error {
+	for _, name := range staleNames {
+		log.Info("unbinding subjects from stale stream", "stream", name)
+		if err := r.NATSClient.UnbindStreamSubjects(ctx, name); err != nil {
+			return fmt.Errorf("unbind subjects from %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// reassignStaleStreams moves messages from stale OTLP source streams into active streams via
+// NATS Stream Sources (server-side move). Returns requeue=true when a transfer is still in
+// progress so the reconciler retries after a short delay.
+func (r *PipelineReconciler) reassignStaleStreams(
+	ctx context.Context,
+	log logr.Logger,
+	p etlv1alpha1.Pipeline,
+	staleNames []string,
+	plan natsResourcePlan,
+) (bool, error) {
+	if len(staleNames) == 0 || len(plan.OTLPSourceStreams) == 0 {
+		return false, nil
+	}
+
+	for i, staleName := range staleNames {
+		destStream := plan.OTLPSourceStreams[i%len(plan.OTLPSourceStreams)]
+
+		msgCount, err := r.NATSClient.GetStreamMessageCount(ctx, staleName)
+		if err != nil {
+			return false, fmt.Errorf("check stale stream %s: %w", staleName, err)
+		}
+		if msgCount == 0 {
+			log.Info("stale stream is empty, deleting", "stream", staleName)
+			if err := r.deleteNATSStream(ctx, log, staleName); err != nil {
+				return false, err
+			}
+			continue
+		}
+
+		// Delete old durable consumer so it doesn't compete with Stream Source for messages.
+		_ = r.NATSClient.DeleteConsumer(ctx, staleName, getNATSSinkConsumerName(p.Spec.ID))
+
+		log.Info("adding stale stream as source for message transfer",
+			"stale_stream", staleName, "dest_stream", destStream.Name, "pending_messages", msgCount)
+		if err := r.NATSClient.AddStreamSource(ctx, destStream.Name, staleName); err != nil {
+			return false, fmt.Errorf("add source %s to %s: %w", staleName, destStream.Name, err)
+		}
+
+		complete, err := r.NATSClient.IsStreamSourceComplete(ctx, destStream.Name, staleName)
+		if err != nil {
+			return false, fmt.Errorf("check source progress %s→%s: %w", staleName, destStream.Name, err)
+		}
+		if !complete {
+			log.Info("stream source transfer in progress, requeuing",
+				"stale_stream", staleName, "dest_stream", destStream.Name)
+			return true, nil
+		}
+
+		log.Info("stream source transfer complete, cleaning up",
+			"stale_stream", staleName, "dest_stream", destStream.Name)
+		if err := r.NATSClient.RemoveStreamSource(ctx, destStream.Name, staleName); err != nil {
+			return false, fmt.Errorf("remove source %s from %s: %w", staleName, destStream.Name, err)
+		}
+		if err := r.deleteNATSStream(ctx, log, staleName); err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
 // createNATSStreams creates all NATS streams and KV stores for a pipeline.
 func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha1.Pipeline) error {
 	plan, err := r.buildNATSResourcePlan(p)
 	if err != nil {
 		return fmt.Errorf("build NATS resource plan: %w", err)
 	}
+	return r.createNATSStreamsFromPlan(ctx, p, plan)
+}
 
-	// create DLQ
-	err = r.NATSClient.CreateOrUpdateStream(ctx, plan.DLQStream)
+// createNATSStreamsFromPlan creates all NATS streams and KV stores from a (possibly overridden) plan.
+func (r *PipelineReconciler) createNATSStreamsFromPlan(ctx context.Context, p etlv1alpha1.Pipeline, plan natsResourcePlan) error {
+	err := r.NATSClient.CreateOrUpdateStream(ctx, plan.DLQStream)
 	if err != nil {
 		r.recordMetricsIfEnabled(func(m *observability.Meter) {
 			m.RecordNATSOperation(ctx, "create_stream", "failure", p.Spec.ID)
@@ -205,22 +338,19 @@ func (r *PipelineReconciler) createNATSStreams(ctx context.Context, p etlv1alpha
 	})
 
 	for _, stream := range plan.OTLPSourceStreams {
-		err = r.NATSClient.CreateOrUpdateStream(ctx, stream)
-		if err != nil {
-			return fmt.Errorf("create stream %s: %w", stream.Name, err)
+		if err = r.NATSClient.CreateOrUpdateStream(ctx, stream); err != nil {
+			return fmt.Errorf("create OTLP source stream %s: %w", stream.Name, err)
 		}
 	}
 
 	for _, stream := range plan.Streams {
-		err = r.NATSClient.CreateOrUpdateStream(ctx, stream)
-		if err != nil {
+		if err = r.NATSClient.CreateOrUpdateStream(ctx, stream); err != nil {
 			return fmt.Errorf("create stream %s: %w", stream.Name, err)
 		}
 	}
 
 	for _, kvStore := range plan.JoinKVStores {
-		err = r.NATSClient.CreateOrUpdateJoinKeyValueStore(ctx, kvStore.Name, kvStore.TTL)
-		if err != nil {
+		if err = r.NATSClient.CreateOrUpdateJoinKeyValueStore(ctx, kvStore.Name, kvStore.TTL); err != nil {
 			return fmt.Errorf("create join KV store %s: %w", kvStore.Name, err)
 		}
 	}

--- a/internal/controller/nats.go
+++ b/internal/controller/nats.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/nats-io/nats.go/jetstream"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/errs"
@@ -313,6 +315,56 @@ func (r *PipelineReconciler) reassignStaleStreams(
 	}
 
 	return false, nil
+}
+
+// setupEditNATSStreams handles the NATS portion of an edit operation: unbinds stale stream
+// subjects (if any), builds and applies the resource plan (with subject override for downscale),
+// creates/updates streams, and drains messages from stale streams via Stream Sources.
+// Returns requeue=true when the drain is still in progress.
+func (r *PipelineReconciler) setupEditNATSStreams(
+	ctx context.Context,
+	log logr.Logger,
+	pipelineID string,
+	p etlv1alpha1.Pipeline,
+	staleNames []string,
+	oldSubjectCount int,
+) (ctrl.Result, error) {
+	if len(staleNames) > 0 {
+		if err := r.unbindStaleStreamSubjects(ctx, log, staleNames); err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("unbind stale stream subjects: %w", err)
+		}
+	}
+
+	plan, err := r.buildNATSResourcePlan(p)
+	if err != nil {
+		r.recordReconcileError(ctx, "edit", pipelineID, err)
+		return ctrl.Result{}, fmt.Errorf("build NATS plan: %w", err)
+	}
+	if oldSubjectCount > len(plan.OTLPSourceStreams) {
+		overrideOTLPSourceSubjects(&plan, oldSubjectCount)
+		log.Info("applied OTLP subject override for downscale",
+			"old_subject_count", oldSubjectCount,
+			"new_stream_count", len(plan.OTLPSourceStreams))
+	}
+
+	if err = r.createNATSStreamsFromPlan(ctx, p, plan); err != nil {
+		r.recordReconcileError(ctx, "edit", pipelineID, err)
+		return ctrl.Result{}, fmt.Errorf("setup streams: %w", err)
+	}
+
+	if len(staleNames) > 0 {
+		requeue, err := r.reassignStaleStreams(ctx, log, p, staleNames, plan)
+		if err != nil {
+			r.recordReconcileError(ctx, "edit", pipelineID, err)
+			return ctrl.Result{}, fmt.Errorf("reassign stale streams: %w", err)
+		}
+		if requeue {
+			return ctrl.Result{Requeue: true, RequeueAfter: 2 * time.Second}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // createNATSStreams creates all NATS streams and KV stores for a pipeline.

--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -169,6 +169,24 @@ func buildOutputStreams(
 	return streams
 }
 
+// staleStreamNames returns stream names that exist in NATS but are not in the planned
+// OTLP source streams or DLQ. On a stopped OTLP pipeline only OTLP source streams + DLQ
+// survive, so only OTLP source streams can be stale after a downscale.
+func staleStreamNames(existingNames []string, newPlan natsResourcePlan) []string {
+	planned := make(map[string]bool, len(newPlan.OTLPSourceStreams)+1)
+	planned[newPlan.DLQStream.Name] = true
+	for _, s := range newPlan.OTLPSourceStreams {
+		planned[s.Name] = true
+	}
+	var stale []string
+	for _, name := range existingNames {
+		if !planned[name] {
+			stale = append(stale, name)
+		}
+	}
+	return stale
+}
+
 func inputBindingStoreName(binding pipelinegraph.InputBinding) (string, error) {
 	if len(binding.Streams) == 0 {
 		return "", fmt.Errorf("input binding has no streams")

--- a/internal/controller/timeout.go
+++ b/internal/controller/timeout.go
@@ -248,6 +248,46 @@ func (r *PipelineReconciler) clearStopLastPendingCount(p *etlv1alpha1.Pipeline) 
 	}
 }
 
+// tryExtendEditDrainTimeout extends the edit operation timeout when NATS Stream Source transfer
+// is still making progress. It sums message counts across stale streams and compares against the
+// last recorded value; returns true (extend) if decreasing, false (give up) if stalled.
+func (r *PipelineReconciler) tryExtendEditDrainTimeout(
+	ctx context.Context,
+	log logr.Logger,
+	p *etlv1alpha1.Pipeline,
+	staleNames []string,
+) (bool, error) {
+	var current uint64
+	for _, name := range staleNames {
+		count, err := r.NATSClient.GetStreamMessageCount(ctx, name)
+		if err != nil {
+			return false, fmt.Errorf("get message count for stale stream %s: %w", name, err)
+		}
+		current += count
+	}
+
+	annotations := p.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	lastStr := annotations[constants.PipelineEditDrainLastMsgCountAnnotation]
+	lastTotal, _ := strconv.ParseUint(lastStr, 10, 64)
+	if lastStr != "" && current >= lastTotal {
+		log.Info("stale stream drain stalled, honoring edit timeout", "pipeline_id", p.Spec.ID, "total_msgs", current)
+		return false, nil
+	}
+
+	log.Info("stale stream drain in progress, extending edit timeout", "pipeline_id", p.Spec.ID, "total_msgs", current)
+	annotations[constants.PipelineEditDrainLastMsgCountAnnotation] = strconv.FormatUint(current, 10)
+	annotations[constants.PipelineOperationStartTimeAnnotation] = time.Now().UTC().Format(time.RFC3339)
+	p.SetAnnotations(annotations)
+	if err := r.Update(ctx, p); err != nil {
+		return false, fmt.Errorf("extend edit drain timeout: %w", err)
+	}
+	return true, nil
+}
+
 // tryExtendStopTimeout checks whether pending messages are still decreasing when a stop operation
 // times out. If the count has decreased since the last check, it extends the timeout window and
 // returns true so the caller can requeue. If no progress is detected, it returns false and the

--- a/internal/controller/timeout.go
+++ b/internal/controller/timeout.go
@@ -248,6 +248,50 @@ func (r *PipelineReconciler) clearStopLastPendingCount(p *etlv1alpha1.Pipeline) 
 	}
 }
 
+// setOTLPDownscaleSubjectCount persists the old OTLP source stream count in an annotation
+// so it survives reconcile passes after stale streams are deleted. Idempotent — only stores
+// on the first call (to preserve the original count).
+func (r *PipelineReconciler) setOTLPDownscaleSubjectCount(ctx context.Context, p *etlv1alpha1.Pipeline, count int) error {
+	annotations := p.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if _, exists := annotations[constants.PipelineOTLPDownscaleOldSubjectCountAnnotation]; exists {
+		return nil
+	}
+	annotations[constants.PipelineOTLPDownscaleOldSubjectCountAnnotation] = strconv.Itoa(count)
+	p.SetAnnotations(annotations)
+	return r.Update(ctx, p)
+}
+
+// getOTLPDownscaleSubjectCount reads the persisted old OTLP subject count annotation.
+// Returns (count, true) if valid, (0, false) otherwise.
+func getOTLPDownscaleSubjectCount(p *etlv1alpha1.Pipeline) (int, bool) {
+	annotations := p.GetAnnotations()
+	if annotations == nil {
+		return 0, false
+	}
+	str, exists := annotations[constants.PipelineOTLPDownscaleOldSubjectCountAnnotation]
+	if !exists {
+		return 0, false
+	}
+	count, err := strconv.Atoi(str)
+	if err != nil || count == 0 {
+		return 0, false
+	}
+	return count, true
+}
+
+// clearOTLPDownscaleSubjectCount removes the old subject count annotation from the pipeline.
+// The caller is responsible for persisting the change via Update.
+func (r *PipelineReconciler) clearOTLPDownscaleSubjectCount(p *etlv1alpha1.Pipeline) {
+	annotations := p.GetAnnotations()
+	if annotations != nil {
+		delete(annotations, constants.PipelineOTLPDownscaleOldSubjectCountAnnotation)
+		p.SetAnnotations(annotations)
+	}
+}
+
 // tryExtendEditDrainTimeout extends the edit operation timeout when NATS Stream Source transfer
 // is still making progress. It sums message counts across stale streams and compares against the
 // last recorded value; returns true (extend) if decreasing, false (give up) if stalled.

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -224,6 +224,135 @@ func (n *NATSClient) CheckConsumerPendingMessages(ctx context.Context, streamNam
 	return hasPending, pending, unacknowledged, nil
 }
 
+// UnbindStreamSubjects updates a stream to a sentinel subject so no real messages
+// can be published to it, releasing ownership of its subjects for another stream to claim.
+func (n *NATSClient) UnbindStreamSubjects(ctx context.Context, streamName string) error {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		return fmt.Errorf("get stream %s: %w", streamName, err)
+	}
+	cfg := stream.CachedInfo().Config
+	cfg.Subjects = []string{streamName + ".__unbound__"}
+	_, err = n.js.CreateOrUpdateStream(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("unbind subjects from stream %s: %w", streamName, err)
+	}
+	return nil
+}
+
+// AddStreamSource configures destStream to pull messages from sourceStream via NATS server-side
+// copy. With WorkQueue retention, messages are removed from sourceStream as they are consumed.
+// Idempotent — adding the same source twice is a no-op.
+func (n *NATSClient) AddStreamSource(ctx context.Context, destStreamName, sourceStreamName string) error {
+	stream, err := n.js.Stream(ctx, destStreamName)
+	if err != nil {
+		return fmt.Errorf("get stream %s: %w", destStreamName, err)
+	}
+	cfg := stream.CachedInfo().Config
+	for _, src := range cfg.Sources {
+		if src.Name == sourceStreamName {
+			return nil
+		}
+	}
+	cfg.Sources = append(cfg.Sources, &jetstream.StreamSource{
+		Name: sourceStreamName,
+	})
+	_, err = n.js.CreateOrUpdateStream(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("add source %s to stream %s: %w", sourceStreamName, destStreamName, err)
+	}
+	return nil
+}
+
+// IsStreamSourceComplete checks if all messages from sourceStream have been
+// transferred to destStream (lag == 0). Returns true if the source is not found (already done).
+func (n *NATSClient) IsStreamSourceComplete(ctx context.Context, destStreamName, sourceStreamName string) (bool, error) {
+	stream, err := n.js.Stream(ctx, destStreamName)
+	if err != nil {
+		return false, fmt.Errorf("get stream %s: %w", destStreamName, err)
+	}
+	info, err := stream.Info(ctx)
+	if err != nil {
+		return false, fmt.Errorf("get stream info %s: %w", destStreamName, err)
+	}
+	for _, src := range info.Sources {
+		if src.Name == sourceStreamName {
+			return src.Lag == 0, nil
+		}
+	}
+	return true, nil
+}
+
+// RemoveStreamSource removes a source from destStream's configuration.
+func (n *NATSClient) RemoveStreamSource(ctx context.Context, destStreamName, sourceStreamName string) error {
+	stream, err := n.js.Stream(ctx, destStreamName)
+	if err != nil {
+		return fmt.Errorf("get stream %s: %w", destStreamName, err)
+	}
+	cfg := stream.CachedInfo().Config
+	filtered := make([]*jetstream.StreamSource, 0, len(cfg.Sources))
+	for _, src := range cfg.Sources {
+		if src.Name != sourceStreamName {
+			filtered = append(filtered, src)
+		}
+	}
+	cfg.Sources = filtered
+	_, err = n.js.CreateOrUpdateStream(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("remove source %s from stream %s: %w", sourceStreamName, destStreamName, err)
+	}
+	return nil
+}
+
+// ListPipelineStreams returns all NATS stream names belonging to this pipeline (by hash prefix).
+func (n *NATSClient) ListPipelineStreams(ctx context.Context, pipelineHash string) ([]string, error) {
+	prefix := fmt.Sprintf("gfm-%s-", pipelineHash)
+	lister := n.js.StreamNames(ctx)
+	var names []string
+	for name := range lister.Name() {
+		if strings.HasPrefix(name, prefix) {
+			names = append(names, name)
+		}
+	}
+	if err := lister.Err(); err != nil {
+		return nil, fmt.Errorf("list streams with prefix %s: %w", prefix, err)
+	}
+	return names, nil
+}
+
+// GetStreamMessageCount returns the number of messages currently in a stream (0 if not found).
+func (n *NATSClient) GetStreamMessageCount(ctx context.Context, streamName string) (uint64, error) {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("get stream %s: %w", streamName, err)
+	}
+	info, err := stream.Info(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("get stream info %s: %w", streamName, err)
+	}
+	return info.State.Msgs, nil
+}
+
+// DeleteConsumer deletes a consumer from a stream. Best-effort — returns nil if
+// the consumer or stream does not exist.
+func (n *NATSClient) DeleteConsumer(ctx context.Context, streamName, consumerName string) error {
+	stream, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil
+		}
+		return fmt.Errorf("get stream %s: %w", streamName, err)
+	}
+	err = stream.DeleteConsumer(ctx, consumerName)
+	if err != nil && !errors.Is(err, jetstream.ErrConsumerNotFound) {
+		return fmt.Errorf("delete consumer %s from stream %s: %w", consumerName, streamName, err)
+	}
+	return nil
+}
+
 func (n *NATSClient) Close() error {
 	n.nc.Close()
 	return nil


### PR DESCRIPTION
# OTLP pipeline: safe sink/dedup downscale

## Problem

When an OTLP pipeline is stopped and then edited to reduce the number of sink (or dedup)
replicas, the operator left behind stale NATS source streams. This caused three issues:

1. **Orphaned messages** — data sitting in stale streams was never consumed.
2. **Subject ownership conflict** — active streams could not claim subjects already owned
   by stale streams, so `CreateOrUpdateStream` failed.
3. **Data loss on the OTLP receiver side** — the shared OTLP receiver caches `SubjectCount`
   per pipeline and does not refresh immediately. If the new active streams cover fewer
   subjects than the cached count, incoming writes land on subjects that no stream owns.

## Solution

The operator now handles OTLP source stream downscale in four steps executed during
`reconcileEdit` for stopped pipelines:

1. **Detect stale streams** — list all NATS streams with the pipeline's hash prefix and
   compare against the new resource plan; anything not in the plan is stale.
2. **Dedup protection** — if stale streams are found and dedup is enabled the operator
   sets the pipeline status to `Failed` with an explanatory message, because dedup uses
   pod-local Badger state that cannot be migrated across replica indices.
3. **Unbind stale stream subjects** — sets a sentinel subject (`<name>.__unbound__`) on
   each stale stream so the active streams can claim the real subjects.
4. **Subject override** — redistributes the *old* subject indices round-robin across the
   *new* (fewer) active streams, so the receiver's cached `SubjectCount` is fully covered
   until it refreshes its config.
5. **Message drain** — uses NATS server-side Stream Sources to move remaining messages
   from each stale stream into a corresponding active stream, then deletes the stale stream
   once the lag reaches zero (with requeue if not yet complete).

## Changes

| File | What changed |
|---|---|
| `internal/nats/client.go` | Added `UnbindStreamSubjects`, `AddStreamSource`, `IsStreamSourceComplete`, `RemoveStreamSource`, `ListPipelineStreams`, `GetStreamMessageCount`, `DeleteConsumer` |
| `internal/controller/nats_resource_plan.go` | Added `OTLPSourceStreams` field to `natsResourcePlan`; added `staleStreamNames` helper |
| `internal/controller/nats.go` | Added `discoverStaleStreams`, `overrideOTLPSourceSubjects`, `unbindStaleStreamSubjects`, `reassignStaleStreams`; refactored `createNATSStreams` → `createNATSStreamsFromPlan` |
| `internal/controller/controller.go` | Wired the full downscale flow into `reconcileEdit`; fixed optimistic-concurrency conflict in dedup-protection status update by re-fetching the pipeline object before writing |
| `config/rbac/role.yaml` | Added `list` verb for streams (required by `ListPipelineStreams`) |
