### PR TITLE
fix: delete stopped pipelines from postgres during helm uninstall

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -40,7 +40,6 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/observability"
-	postgresstorage "github.com/glassflow/glassflow-etl-k8s-operator/internal/storage/postgres"
 	"github.com/glassflow/glassflow-etl-k8s-operator/pkg/usagestats"
 )
 
@@ -76,6 +75,12 @@ var pipelineOperationPredicate = predicate.Funcs{
 	},
 }
 
+// pipelineStorage is the subset of postgres.PostgresStorage used by the controller.
+type pipelineStorage interface {
+	DeletePipeline(ctx context.Context, pipelineID string) error
+	UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string) error
+}
+
 // -------------------------------------------------------------------------------------------------------------------
 
 // PipelineReconciler reconciles a Pipeline object
@@ -84,7 +89,7 @@ type PipelineReconciler struct {
 	Scheme           *runtime.Scheme
 	Meter            *observability.Meter
 	NATSClient       *nats.NATSClient
-	PostgresStorage  *postgresstorage.PostgresStorage
+	PostgresStorage  pipelineStorage
 	Config           ReconcilerConfig
 	UsageStatsClient *usagestats.Client
 }
@@ -336,14 +341,12 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 	}
 
 	// Clean up pipeline configuration from PostgreSQL
-	if r.PostgresStorage != nil {
-		err = r.PostgresStorage.DeletePipeline(ctx, p.Spec.ID)
-		if err != nil {
-			log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID, "error", err)
-			// Don't return error here - we're in force cleanup mode
-		} else {
-			log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID)
-		}
+	err = r.PostgresStorage.DeletePipeline(ctx, p.Spec.ID)
+	if err != nil {
+		log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID, "error", err)
+		// Don't return error here - we're in force cleanup mode
+	} else {
+		log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID)
 	}
 
 	r.clearOperationAnnotationAndStatus(
@@ -383,6 +386,14 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 	// Check if pipeline is already stopped
 	if p.Status == etlv1alpha1.PipelineStatus(models.PipelineStatusStopped) {
 		log.Info("pipeline already stopped during helm uninstall", "pipeline_id", pipelineID)
+
+		// Delete pipeline configuration from PostgreSQL for stopped pipelines
+		if err := r.PostgresStorage.DeletePipeline(ctx, pipelineID); err != nil {
+			log.Info("failed to delete stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
+		} else {
+			log.Info("successfully deleted stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
+		}
+
 		// Remove helm uninstall annotation and finalizer to allow cleanup
 		annotations := p.GetAnnotations()
 		if annotations != nil {
@@ -422,14 +433,12 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 	}
 
 	// Clean up pipeline configuration from PostgreSQL
-	if r.PostgresStorage != nil {
-		err = r.PostgresStorage.DeletePipeline(ctx, pipelineID)
-		if err != nil {
-			log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
-			// Don't return error here - we're in force cleanup mode
-		} else {
-			log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
-		}
+	err = r.PostgresStorage.DeletePipeline(ctx, pipelineID)
+	if err != nil {
+		log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
+		// Don't return error here - we're in force cleanup mode
+	} else {
+		log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
 	}
 
 	// Remove all pipeline operation annotations

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -63,15 +64,19 @@ func (c *helmUninstallTestClient) Delete(_ context.Context, obj client.Object, _
 	return nil
 }
 
-// fakeStorage records DeletePipeline calls.
+// fakeStorage records DeletePipeline calls and can simulate errors.
 type fakeStorage struct {
 	mu      sync.Mutex
 	deleted []string
+	returnErr error
 }
 
 func (f *fakeStorage) DeletePipeline(_ context.Context, pipelineID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if f.returnErr != nil {
+		return f.returnErr
+	}
 	f.deleted = append(f.deleted, pipelineID)
 	return nil
 }
@@ -132,10 +137,10 @@ func TestReconcileHelmUninstallDeletesStoppedPipelineFromPostgres(t *testing.T) 
 	}
 }
 
-func TestReconcileHelmUninstallDeletesStoppedPipelineWithNilPostgres(t *testing.T) {
+func TestReconcileHelmUninstallStoppedPipelineDeleteErrorIsNonFatal(t *testing.T) {
 	t.Parallel()
 
-	const pipelineID = "stopped-pipeline-nil-postgres"
+	const pipelineID = "stopped-pipeline-delete-error"
 
 	pipeline := &etlv1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
@@ -155,22 +160,24 @@ func TestReconcileHelmUninstallDeletesStoppedPipelineWithNilPostgres(t *testing.
 			{Name: pipeline.Name, Namespace: pipeline.Namespace}: pipeline.DeepCopy(),
 		},
 	}
+	storage := &fakeStorage{returnErr: fmt.Errorf("postgres unavailable")}
 
 	r := &PipelineReconciler{
 		Client:          fakeClient,
-		PostgresStorage: nil,
+		PostgresStorage: storage,
 	}
 
 	_, err := r.reconcileHelmUninstall(context.Background(), logr.Discard(), *pipeline)
 	if err != nil {
-		t.Fatalf("reconcileHelmUninstall() returned unexpected error with nil postgres: %v", err)
+		t.Fatalf("reconcileHelmUninstall() should not return error when postgres delete fails: %v", err)
 	}
 
+	// CRD should still be deleted even if postgres failed
 	fakeClient.mu.Lock()
 	deletedCRDs := fakeClient.deleted
 	fakeClient.mu.Unlock()
 
 	if len(deletedCRDs) != 1 || deletedCRDs[0] != pipelineID {
-		t.Fatalf("expected CRD to be deleted even with nil postgres, got deletedCRDs=%v", deletedCRDs)
+		t.Fatalf("expected CRD to be deleted even on postgres error, got deletedCRDs=%v", deletedCRDs)
 	}
 }

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -66,8 +66,8 @@ func (c *helmUninstallTestClient) Delete(_ context.Context, obj client.Object, _
 
 // fakeStorage records DeletePipeline calls and can simulate errors.
 type fakeStorage struct {
-	mu      sync.Mutex
-	deleted []string
+	mu        sync.Mutex
+	deleted   []string
 	returnErr error
 }
 

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -1,0 +1,176 @@
+package controller
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+)
+
+// helmUninstallTestClient is a minimal fake client for helm-uninstall tests.
+type helmUninstallTestClient struct {
+	client.Client
+	mu      sync.Mutex
+	objects map[types.NamespacedName]*etlv1alpha1.Pipeline
+	deleted []string
+}
+
+func (c *helmUninstallTestClient) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	pipeline, ok := obj.(*etlv1alpha1.Pipeline)
+	if !ok {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	if !exists {
+		return nil
+	}
+	*pipeline = *stored.DeepCopy()
+	return nil
+}
+
+func (c *helmUninstallTestClient) Update(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+	pipeline, ok := obj.(*etlv1alpha1.Pipeline)
+	if !ok {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}
+	c.objects[key] = pipeline.DeepCopy()
+	return nil
+}
+
+func (c *helmUninstallTestClient) Delete(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+	pipeline, ok := obj.(*etlv1alpha1.Pipeline)
+	if !ok {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}
+	delete(c.objects, key)
+	c.deleted = append(c.deleted, pipeline.Spec.ID)
+	return nil
+}
+
+// fakeStorage records DeletePipeline calls.
+type fakeStorage struct {
+	mu      sync.Mutex
+	deleted []string
+}
+
+func (f *fakeStorage) DeletePipeline(_ context.Context, pipelineID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, pipelineID)
+	return nil
+}
+
+func (f *fakeStorage) UpdatePipelineStatus(_ context.Context, _ string, _ models.PipelineStatus, _ []string) error {
+	return nil
+}
+
+func TestReconcileHelmUninstallDeletesStoppedPipelineFromPostgres(t *testing.T) {
+	t.Parallel()
+
+	const pipelineID = "stopped-pipeline-id"
+
+	pipeline := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stopped-pipeline",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineHelmUninstallAnnotation: "true",
+			},
+			Finalizers: []string{constants.PipelineFinalizerName},
+		},
+		Spec:   etlv1alpha1.PipelineSpec{ID: pipelineID},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusStopped),
+	}
+
+	fakeClient := &helmUninstallTestClient{
+		objects: map[types.NamespacedName]*etlv1alpha1.Pipeline{
+			{Name: pipeline.Name, Namespace: pipeline.Namespace}: pipeline.DeepCopy(),
+		},
+	}
+	storage := &fakeStorage{}
+
+	r := &PipelineReconciler{
+		Client:          fakeClient,
+		PostgresStorage: storage,
+	}
+
+	_, err := r.reconcileHelmUninstall(context.Background(), logr.Discard(), *pipeline)
+	if err != nil {
+		t.Fatalf("reconcileHelmUninstall() returned unexpected error: %v", err)
+	}
+
+	storage.mu.Lock()
+	deletedIDs := storage.deleted
+	storage.mu.Unlock()
+
+	if len(deletedIDs) != 1 || deletedIDs[0] != pipelineID {
+		t.Fatalf("expected postgres DeletePipeline(%q), got deletedIDs=%v", pipelineID, deletedIDs)
+	}
+
+	fakeClient.mu.Lock()
+	deletedCRDs := fakeClient.deleted
+	fakeClient.mu.Unlock()
+
+	if len(deletedCRDs) != 1 || deletedCRDs[0] != pipelineID {
+		t.Fatalf("expected CRD to be deleted, got deletedCRDs=%v", deletedCRDs)
+	}
+}
+
+func TestReconcileHelmUninstallDeletesStoppedPipelineWithNilPostgres(t *testing.T) {
+	t.Parallel()
+
+	const pipelineID = "stopped-pipeline-nil-postgres"
+
+	pipeline := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stopped-pipeline-2",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineHelmUninstallAnnotation: "true",
+			},
+			Finalizers: []string{constants.PipelineFinalizerName},
+		},
+		Spec:   etlv1alpha1.PipelineSpec{ID: pipelineID},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusStopped),
+	}
+
+	fakeClient := &helmUninstallTestClient{
+		objects: map[types.NamespacedName]*etlv1alpha1.Pipeline{
+			{Name: pipeline.Name, Namespace: pipeline.Namespace}: pipeline.DeepCopy(),
+		},
+	}
+
+	r := &PipelineReconciler{
+		Client:          fakeClient,
+		PostgresStorage: nil,
+	}
+
+	_, err := r.reconcileHelmUninstall(context.Background(), logr.Discard(), *pipeline)
+	if err != nil {
+		t.Fatalf("reconcileHelmUninstall() returned unexpected error with nil postgres: %v", err)
+	}
+
+	fakeClient.mu.Lock()
+	deletedCRDs := fakeClient.deleted
+	fakeClient.mu.Unlock()
+
+	if len(deletedCRDs) != 1 || deletedCRDs[0] != pipelineID {
+		t.Fatalf("expected CRD to be deleted even with nil postgres, got deletedCRDs=%v", deletedCRDs)
+	}
+}

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -86,21 +86,18 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 	// Status validation is now handled by the backend API, so we trust the status update
 
 	// Update PostgreSQL storage
-	if r.PostgresStorage != nil {
-		pgStatus := newStatus
-		err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors)
-		if err != nil {
-			log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
-			// Don't fail the reconciliation if PostgreSQL update fails, just log the error
-		} else {
-			log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
-		}
+	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, newStatus, errors)
+	if err != nil {
+		log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
+		// Don't fail the reconciliation if PostgreSQL update fails, just log the error
+	} else {
+		log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
 	}
 
 	// Update CRD status
 	oldStatus := string(p.Status)
 	p.Status = etlv1alpha1.PipelineStatus(newStatus)
-	err := r.Status().Update(ctx, p, &client.SubResourceUpdateOptions{})
+	err = r.Status().Update(ctx, p, &client.SubResourceUpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("update pipeline CRD status: %w", err)
 	}


### PR DESCRIPTION
Stopped pipelines were not being removed from PostgreSQL when helm uninstall ran because the early-return path for already-stopped pipelines skipped the postgres cleanup that only existed further down the function for running pipelines.

Also introduces a pipelineStorage interface so the behaviour can be covered by a unit test without a live database.