### PR TITLE
feat: include stop reason in pipeline history event

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,14 +18,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumeclaims
-  verbs:
-  - delete
-  - get
-  - list
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/internal/consumers/component_signals_consumer.go
+++ b/internal/consumers/component_signals_consumer.go
@@ -171,7 +171,7 @@ func (c *ComponentSignalsConsumer) stopPipeline(ctx context.Context, message mod
 		return fmt.Errorf("update pipeline CRD with stop annotation: %w", err)
 	}
 
-	err = c.storage.UpdatePipelineStatus(ctx, message.PipelineID, models.PipelineStatusStopping, nil)
+	err = c.storage.UpdatePipelineStatus(ctx, message.PipelineID, models.PipelineStatusStopping, nil, message.Text)
 	if err != nil {
 		return fmt.Errorf("update pipeline status: %w", err)
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -78,7 +78,7 @@ var pipelineOperationPredicate = predicate.Funcs{
 // pipelineStorage is the subset of postgres.PostgresStorage used by the controller.
 type pipelineStorage interface {
 	DeletePipeline(ctx context.Context, pipelineID string) error
-	UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string) error
+	UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string, reason string) error
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -236,7 +236,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 	}
 
 	// All deployments are ready, update status to Running
-	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil)
+	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil, "create")
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
@@ -285,7 +285,7 @@ func (r *PipelineReconciler) reconcileTerminate(ctx context.Context, log logr.Lo
 	}
 
 	// Update pipeline status to "Stopped"
-	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopped, nil)
+	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopped, nil, "terminate")
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to stopped: %w", err)
 	}
@@ -501,7 +501,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 		// Continue with the resume process
 	} else {
 		// Transition to Resuming status first
-		err := r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusResuming, nil)
+		err := r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusResuming, nil, "resume")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to resuming: %w", err)
 		}
@@ -563,7 +563,7 @@ func (r *PipelineReconciler) reconcileResume(ctx context.Context, log logr.Logge
 	}
 
 	// All deployments are ready, update status to Running
-	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil)
+	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil, "resume")
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}
@@ -619,7 +619,7 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		// Continue with the stop process
 	} else {
 		// Transition to Stopping status first
-		err := r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopping, nil)
+		err := r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopping, nil, "stop")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to stopping: %w", err)
 		}
@@ -646,7 +646,7 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 	}
 
 	// Update status to Stopped
-	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopped, nil)
+	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusStopped, nil, "stop")
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to stopped: %w", err)
 	}
@@ -739,7 +739,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		// Continue with the resume process
 	} else {
 		// Transition status to Resuming
-		err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusResuming, nil)
+		err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusResuming, nil, "edit")
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("update pipeline status to resuming: %w", err)
 		}
@@ -764,7 +764,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 		if err = r.Get(ctx, types.NamespacedName{Name: p.Name, Namespace: p.Namespace}, &p); err != nil {
 			return ctrl.Result{}, fmt.Errorf("refresh pipeline before status update: %w", err)
 		}
-		if err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusFailed, []string{msg}); err != nil {
+		if err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusFailed, []string{msg}, "edit"); err != nil {
 			return ctrl.Result{}, fmt.Errorf("update pipeline status: %w", err)
 		}
 		return ctrl.Result{}, nil
@@ -795,7 +795,7 @@ func (r *PipelineReconciler) reconcileEdit(ctx context.Context, log logr.Logger,
 	}
 
 	// All deployments are ready, update status to Running
-	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil)
+	err = r.updatePipelineStatus(ctx, log, &p, models.PipelineStatusRunning, nil, "edit")
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("update pipeline status to running: %w", err)
 	}

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -81,7 +81,7 @@ func (f *fakeStorage) DeletePipeline(_ context.Context, pipelineID string) error
 	return nil
 }
 
-func (f *fakeStorage) UpdatePipelineStatus(_ context.Context, _ string, _ models.PipelineStatus, _ []string) error {
+func (f *fakeStorage) UpdatePipelineStatus(_ context.Context, _ string, _ models.PipelineStatus, _ []string, _ string) error {
 	return nil
 }
 

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -87,7 +87,7 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 
 	// Update PostgreSQL storage
 	pgStatus := newStatus
-	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, "")
+	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, string(newStatus))
 	if err != nil {
 		log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
 		// Don't fail the reconciliation if PostgreSQL update fails, just log the error

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -75,7 +75,7 @@ func (r *PipelineReconciler) recordMetricsIfEnabled(fn func(*observability.Meter
 }
 
 // updatePipelineStatus updates PostgreSQL and CRD status (validation handled by backend API)
-func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.Logger, p *etlv1alpha1.Pipeline, newStatus models.PipelineStatus, errors []string) error {
+func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.Logger, p *etlv1alpha1.Pipeline, newStatus models.PipelineStatus, errors []string, reason string) error {
 	// Check if status is already the same - avoid duplicate updates and history entries
 	currentStatus := models.PipelineStatus(p.Status)
 	if currentStatus == newStatus {
@@ -87,7 +87,7 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 
 	// Update PostgreSQL storage
 	pgStatus := newStatus
-	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, string(newStatus))
+	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, reason)
 	if err != nil {
 		log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
 		// Don't fail the reconciliation if PostgreSQL update fails, just log the error

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -86,14 +86,14 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 	// Status validation is now handled by the backend API, so we trust the status update
 
 	// Update PostgreSQL storage
-  pgStatus := newStatus
-  err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, "")
-  if err != nil {
-    log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
-    // Don't fail the reconciliation if PostgreSQL update fails, just log the error
-  } else {
-    log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
-  }
+	pgStatus := newStatus
+	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, "")
+	if err != nil {
+		log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
+		// Don't fail the reconciliation if PostgreSQL update fails, just log the error
+	} else {
+		log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
+	}
 
 	// Update CRD status
 	oldStatus := string(p.Status)

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -88,7 +88,7 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 	// Update PostgreSQL storage
 	if r.PostgresStorage != nil {
 		pgStatus := newStatus
-		err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors)
+		err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, "")
 		if err != nil {
 			log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
 			// Don't fail the reconciliation if PostgreSQL update fails, just log the error

--- a/internal/controller/timeout.go
+++ b/internal/controller/timeout.go
@@ -153,7 +153,7 @@ func (r *PipelineReconciler) handleOperationTimeout(ctx context.Context, log log
 
 	// Update status to Failed with error message
 	errorMsg := fmt.Sprintf("operation timed out after %v", constants.ReconcileTimeout)
-	err := r.updatePipelineStatus(ctx, log, p, models.PipelineStatusFailed, []string{errorMsg})
+	err := r.updatePipelineStatus(ctx, log, p, models.PipelineStatusFailed, []string{errorMsg}, "timeout")
 	if err != nil {
 		log.Error(err, "failed to update pipeline status to Failed", "pipeline_id", pipelineID)
 		// Continue anyway to clear annotations

--- a/internal/storage/postgres/pipelines.go
+++ b/internal/storage/postgres/pipelines.go
@@ -12,7 +12,7 @@ import (
 )
 
 // UpdatePipelineStatus updates the pipeline status and creates a history event
-func (s *PostgresStorage) UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string) error {
+func (s *PostgresStorage) UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string, reason string) error {
 
 	// Begin transaction
 	tx, err := s.pool.Begin(ctx)
@@ -46,7 +46,7 @@ func (s *PostgresStorage) UpdatePipelineStatus(ctx context.Context, pipelineID s
 	}
 
 	// Create history event with type "status" or "error" (depending on errors parameter)
-	err = s.insertPipelineHistoryEvent(ctx, tx, pipelineID, statusStr, errors)
+	err = s.insertPipelineHistoryEvent(ctx, tx, pipelineID, statusStr, errors, reason)
 	if err != nil {
 		// Log but don't fail the status update
 		s.logger.Info("failed to insert pipeline history event", "pipeline_id", pipelineID, "error", err)
@@ -65,13 +65,14 @@ func (s *PostgresStorage) UpdatePipelineStatus(ctx context.Context, pipelineID s
 
 // HistoryEntry represents a pipeline history entry
 type HistoryEntry struct {
-	Type     string          `json:"type"`     // "history", "error", or "status"
-	Pipeline json.RawMessage `json:"pipeline"` // Full pipeline JSON
-	Errors   []string        `json:"errors"`   // Array of error messages (for error type)
+	Type     string          `json:"type"`             // "history", "error", or "status"
+	Pipeline json.RawMessage `json:"pipeline"`         // Full pipeline JSON
+	Errors   []string        `json:"errors"`           // Array of error messages (for error type)
+	Reason   string          `json:"reason,omitempty"` // Optional reason for the status change
 }
 
 // insertPipelineHistoryEvent inserts a pipeline history event
-func (s *PostgresStorage) insertPipelineHistoryEvent(ctx context.Context, tx pgx.Tx, pipelineID string, status string, errors []string) error {
+func (s *PostgresStorage) insertPipelineHistoryEvent(ctx context.Context, tx pgx.Tx, pipelineID string, status string, errors []string, reason string) error {
 	// Determine event type: "error" if errors present, otherwise "status"
 	eventType := "status"
 	if len(errors) > 0 {
@@ -87,6 +88,7 @@ func (s *PostgresStorage) insertPipelineHistoryEvent(ctx context.Context, tx pgx
 		Type:     eventType,
 		Pipeline: pipelineJSON,
 		Errors:   errors,
+		Reason:   reason,
 	}
 
 	eventJSON, err := json.Marshal(event)


### PR DESCRIPTION
## Summary
- Added `reason string` parameter to `UpdatePipelineStatus` and `insertPipelineHistoryEvent`
- Added `Reason` field to `HistoryEntry` (omitted from JSON when empty)
- Component signals consumer now passes `message.Text` as the reason when initiating a component-triggered stop

Closes ETL-918