### PR TITLE
feat: set DiscardNew on pipeline internal NATS streams

### DIFF
--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
+
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/pipelinegraph"
@@ -72,8 +74,10 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 		switch node.Type {
 		case pipelinegraph.NodeTypeJoin:
 			nodePlan, err = buildJoinNodePlan(graph, node, p.Spec.Join, maxAge, maxBytes)
-		case pipelinegraph.NodeTypeIngestor, pipelinegraph.NodeTypeOTLPSource, pipelinegraph.NodeTypeDedup:
-			nodePlan, err = buildNodePlan(graph, node, maxAge, maxBytes)
+		case pipelinegraph.NodeTypeIngestor, pipelinegraph.NodeTypeDedup:
+			nodePlan, err = buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardNew)
+		case pipelinegraph.NodeTypeOTLPSource:
+			nodePlan, err = buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardOld)
 		// sink doesn't have output
 		default:
 			continue
@@ -99,6 +103,7 @@ func buildNodePlan(
 	node pipelinegraph.NodeConfig,
 	maxAge time.Duration,
 	maxBytes int64,
+	discard jetstream.DiscardPolicy,
 ) (natsNodePlan, error) {
 	output, err := graph.GetOutput(node.ID)
 	if err != nil {
@@ -106,7 +111,7 @@ func buildNodePlan(
 	}
 
 	return natsNodePlan{
-		Streams: buildOutputStreams(output, maxAge, maxBytes),
+		Streams: buildOutputStreams(output, maxAge, maxBytes, discard),
 	}, nil
 }
 
@@ -117,7 +122,7 @@ func buildJoinNodePlan(
 	maxAge time.Duration,
 	maxBytes int64,
 ) (natsNodePlan, error) {
-	producerPlan, err := buildNodePlan(graph, node, maxAge, maxBytes)
+	producerPlan, err := buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardNew)
 	if err != nil {
 		return natsNodePlan{}, err
 	}
@@ -156,6 +161,7 @@ func buildOutputStreams(
 	output pipelinegraph.OutputBinding,
 	maxAge time.Duration,
 	maxBytes int64,
+	discard jetstream.DiscardPolicy,
 ) []nats.StreamConfig {
 	streams := make([]nats.StreamConfig, 0, len(output.Streams))
 	for _, stream := range output.Streams {
@@ -164,6 +170,7 @@ func buildOutputStreams(
 			Subjects: stream.Subjects,
 			MaxAge:   maxAge,
 			MaxBytes: maxBytes,
+			Discard:  discard,
 		})
 	}
 	return streams

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -63,12 +64,14 @@ func TestBuildNATSResourcePlanJoinless(t *testing.T) {
 			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out.0", hash)},
 			MaxAge:   5 * time.Minute,
 			MaxBytes: 42,
+			Discard:  jetstream.DiscardNew,
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-ingestor-out_1", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor-out.1", hash)},
 			MaxAge:   5 * time.Minute,
 			MaxBytes: 42,
+			Discard:  jetstream.DiscardNew,
 		},
 	}
 	if !reflect.DeepEqual(plan.Streams, wantStreams) {
@@ -129,6 +132,7 @@ func TestBuildNATSResourcePlanJoinWithKVStores(t *testing.T) {
 				fmt.Sprintf("gfm-%s-ingestor_left-out.0", hash),
 				fmt.Sprintf("gfm-%s-ingestor_left-out.1", hash),
 			},
+			Discard: jetstream.DiscardNew,
 		},
 		{
 			Name: fmt.Sprintf("gfm-%s-ingestor_right-out_0", hash),
@@ -136,10 +140,12 @@ func TestBuildNATSResourcePlanJoinWithKVStores(t *testing.T) {
 				fmt.Sprintf("gfm-%s-ingestor_right-out.0", hash),
 				fmt.Sprintf("gfm-%s-ingestor_right-out.2", hash),
 			},
+			Discard: jetstream.DiscardNew,
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-ingestor_right-out_1", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-ingestor_right-out.1", hash)},
+			Discard:  jetstream.DiscardNew,
 		},
 		{
 			Name: fmt.Sprintf("gfm-%s-dedup_right-out_0", hash),
@@ -147,10 +153,12 @@ func TestBuildNATSResourcePlanJoinWithKVStores(t *testing.T) {
 				fmt.Sprintf("gfm-%s-dedup_right-out.0", hash),
 				fmt.Sprintf("gfm-%s-dedup_right-out.1", hash),
 			},
+			Discard: jetstream.DiscardNew,
 		},
 		{
 			Name:     fmt.Sprintf("gfm-%s-join-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-join-out.0", hash)},
+			Discard:  jetstream.DiscardNew,
 		},
 	}
 	if !reflect.DeepEqual(plan.Streams, wantStreams) {
@@ -246,6 +254,7 @@ func TestBuildNATSResourcePlanOTLPWithDedup(t *testing.T) {
 		{
 			Name:     fmt.Sprintf("gfm-%s-dedup-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-dedup-out.0", hash)},
+			Discard:  jetstream.DiscardNew,
 		},
 	}
 	if !reflect.DeepEqual(plan.Streams, wantStreams) {
@@ -312,4 +321,82 @@ func TestBuildNATSResourcePlanJoinWithLeftDedupKVStores(t *testing.T) {
 	if !reflect.DeepEqual(plan.JoinKVStores, wantJoinKVStores) {
 		t.Fatalf("plan.JoinKVStores = %#v, want %#v", plan.JoinKVStores, wantJoinKVStores)
 	}
+}
+
+// TestBuildNATSResourcePlanDiscardPolicy verifies that pipeline internal streams are created
+// with DiscardNew, while DLQ and OTLP source streams retain DiscardOld.
+func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{NATSClient: &nats.NATSClient{}}
+
+	t.Run("pipeline streams have DiscardNew", func(t *testing.T) {
+		t.Parallel()
+		pipeline := etlv1alpha1.Pipeline{
+			Spec: etlv1alpha1.PipelineSpec{
+				ID: "pipe-discard",
+				Source: etlv1alpha1.Sources{
+					Type: "kafka",
+					Streams: []etlv1alpha1.SourceStream{
+						{TopicName: "events"},
+					},
+				},
+				Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			},
+		}
+		plan, err := reconciler.buildNATSResourcePlan(pipeline)
+		if err != nil {
+			t.Fatalf("buildNATSResourcePlan() error: %v", err)
+		}
+		for _, s := range plan.Streams {
+			if s.Discard != jetstream.DiscardNew {
+				t.Errorf("stream %s: Discard = %v, want DiscardNew", s.Name, s.Discard)
+			}
+		}
+	})
+
+	t.Run("DLQ stream has DiscardOld", func(t *testing.T) {
+		t.Parallel()
+		pipeline := etlv1alpha1.Pipeline{
+			Spec: etlv1alpha1.PipelineSpec{
+				ID: "pipe-dlq-discard",
+				Source: etlv1alpha1.Sources{
+					Type: "kafka",
+					Streams: []etlv1alpha1.SourceStream{
+						{TopicName: "events"},
+					},
+				},
+				Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			},
+		}
+		plan, err := reconciler.buildNATSResourcePlan(pipeline)
+		if err != nil {
+			t.Fatalf("buildNATSResourcePlan() error: %v", err)
+		}
+		if plan.DLQStream.Discard != jetstream.DiscardOld {
+			t.Errorf("DLQ stream: Discard = %v, want DiscardOld", plan.DLQStream.Discard)
+		}
+	})
+
+	t.Run("OTLP source streams have DiscardOld", func(t *testing.T) {
+		t.Parallel()
+		pipeline := etlv1alpha1.Pipeline{
+			Spec: etlv1alpha1.PipelineSpec{
+				ID: "pipe-otlp-discard",
+				Source: etlv1alpha1.Sources{
+					Type: etlv1alpha1.SourceTypeOTLPLogs,
+				},
+				Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			},
+		}
+		plan, err := reconciler.buildNATSResourcePlan(pipeline)
+		if err != nil {
+			t.Fatalf("buildNATSResourcePlan() error: %v", err)
+		}
+		for _, s := range plan.OTLPSourceStreams {
+			if s.Discard != jetstream.DiscardOld {
+				t.Errorf("OTLP source stream %s: Discard = %v, want DiscardOld", s.Name, s.Discard)
+			}
+		}
+	})
 }

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -123,6 +123,7 @@ type StreamConfig struct {
 	Subjects []string // if empty, defaults to []string{Name + ".*"}
 	MaxAge   time.Duration
 	MaxBytes int64
+	Discard  jetstream.DiscardPolicy
 }
 
 // DefaultStreamLimits returns the operator-level default stream limits.
@@ -145,7 +146,7 @@ func (n *NATSClient) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig)
 
 		MaxAge:   cfg.MaxAge,
 		MaxBytes: cfg.MaxBytes,
-		Discard:  jetstream.DiscardOld,
+		Discard:  cfg.Discard,
 
 		Retention:          n.retention,
 		AllowDirect:        n.allowDirect,


### PR DESCRIPTION
Pipeline internal streams (ingestor→transform, dedup→sink, join→sink, etc.) now use DiscardNew so that publishes are rejected when a stream is full instead of silently dropping older messages. DLQ and OTLP source streams are intentionally left with DiscardOld as their semantics differ.

Closes ETL-1030