### PR TITLE
ETL-1020: expose MaxMsgs stream limit in pipeline resources config

### DIFF
--- a/api/v1alpha1/pipeline_types.go
+++ b/api/v1alpha1/pipeline_types.go
@@ -118,6 +118,9 @@ type NatsResources struct {
 type NatsStreamResources struct {
 	MaxAge   metav1.Duration   `json:"maxAge,omitempty"`
 	MaxBytes resource.Quantity `json:"maxBytes,omitempty"`
+	// MaxMsgs sets the maximum number of messages the stream will store.
+	// NATS treats both 0 and -1 as unlimited; omitting this field (zero value) means use the operator default.
+	MaxMsgs int64 `json:"maxMsgs,omitempty"`
 }
 
 // IngestorResources defines resources for ingestor components.

--- a/charts/glassflow-operator/templates/pipeline-crd.yaml
+++ b/charts/glassflow-operator/templates/pipeline-crd.yaml
@@ -368,6 +368,12 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          maxMsgs:
+                            description: MaxMsgs sets the maximum number of messages
+                              the stream will store. NATS treats both 0 and -1 as unlimited;
+                              omitting this field (zero value) means use the operator default.
+                            format: int64
+                            type: integer
                         type: object
                     type: object
                   sink:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,7 @@ func main() {
 		"NATS_MAX_STREAM_BYTES", "107374182400"),
 		"Maximum bytes for NATS streams (default: 100GB)")
 	flag.StringVar(&natsMaxStreamMsgs, "nats-max-stream-msgs", getEnvOrDefault(
-		"NATS_MAX_STREAM_MSGS", "1000000"),
+		"NATS_MAX_STREAM_MSGS", "500000"),
 		"Maximum message count for NATS streams (default: 1M)")
 
 	// NATS stream policy configuration
@@ -516,7 +516,7 @@ func main() {
 	}
 
 	maxMsgs, err := strconv.ParseInt(natsMaxStreamMsgs, 10, 64)
-	if err != nil || maxMsgs < 0 {
+	if err != nil || maxMsgs < -1 {
 		setupLog.Error(err, "unable to parse nats max stream msgs, using default",
 			"value", natsMaxStreamMsgs, "default", "1000000")
 		maxMsgs = nats.DefaultStreamMaxMsgs

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -112,13 +112,16 @@ func main() {
 	}
 
 	// NATS stream configuration
-	var natsMaxStreamAge, natsMaxStreamBytes string
+	var natsMaxStreamAge, natsMaxStreamBytes, natsMaxStreamMsgs string
 	flag.StringVar(&natsMaxStreamAge, "nats-max-stream-age", getEnvOrDefault(
 		"NATS_MAX_STREAM_AGE", "168h"),
 		"Maximum age for NATS streams (default: 7 days)")
 	flag.StringVar(&natsMaxStreamBytes, "nats-max-stream-bytes", getEnvOrDefault(
 		"NATS_MAX_STREAM_BYTES", "107374182400"),
 		"Maximum bytes for NATS streams (default: 100GB)")
+	flag.StringVar(&natsMaxStreamMsgs, "nats-max-stream-msgs", getEnvOrDefault(
+		"NATS_MAX_STREAM_MSGS", "1000000"),
+		"Maximum message count for NATS streams (default: 1M)")
 
 	// NATS stream policy configuration
 	var natsStreamRetention, natsStreamAllowDirect, natsStreamAllowAtomicPublish string
@@ -512,6 +515,13 @@ func main() {
 		maxBytes = 107374182400 // 100GB default
 	}
 
+	maxMsgs, err := strconv.ParseInt(natsMaxStreamMsgs, 10, 64)
+	if err != nil || maxMsgs < 0 {
+		setupLog.Error(err, "unable to parse nats max stream msgs, using default",
+			"value", natsMaxStreamMsgs, "default", "1000000")
+		maxMsgs = nats.DefaultStreamMaxMsgs
+	}
+
 	// Parse NATS stream policy configuration
 	retention := nats.ParseRetentionPolicy(natsStreamRetention)
 
@@ -541,6 +551,7 @@ func main() {
 		URL:                natsOperatorAddr,
 		MaxAge:             maxAge,
 		MaxBytes:           maxBytes,
+		MaxMsgs:            maxMsgs,
 		Retention:          retention,
 		AllowDirect:        allowDirect,
 		AllowAtomicPublish: allowAtomicPublish,
@@ -550,11 +561,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	defaultMaxAge, defaultMaxBytes := natsClient.DefaultStreamLimits()
+	defaultMaxAge, defaultMaxBytes, defaultMaxMsgs := natsClient.DefaultStreamLimits()
 	if err := natsClient.CreateOrUpdateStream(ctx, nats.StreamConfig{
 		Name:     constants.ComponentSignalsStream,
 		MaxAge:   defaultMaxAge,
 		MaxBytes: defaultMaxBytes,
+		MaxMsgs:  defaultMaxMsgs,
 	}); err != nil {
 		setupLog.Error(err, "unable to create component signals messages stream")
 		os.Exit(1)

--- a/config/crd/bases/etl.glassflow.io_pipelines.yaml
+++ b/config/crd/bases/etl.glassflow.io_pipelines.yaml
@@ -368,6 +368,12 @@ spec:
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          maxMsgs:
+                            description: MaxMsgs sets the maximum number of messages
+                              the stream will store. NATS treats both 0 and -1 as unlimited;
+                              omitting this field (zero value) means use the operator default.
+                            format: int64
+                            type: integer
                         type: object
                     type: object
                   sink:

--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -75,11 +75,11 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 	}
 
 	plan := natsResourcePlan{
+		// DLQ has no capacity limits — it must absorb all failed events regardless of volume.
+		// MaxAge=0, MaxBytes=0, MaxMsgs=0 are all interpreted as unlimited by NATS.
+		// Discard policy is left as the zero value (DiscardOld) but is irrelevant with no limits.
 		DLQStream: nats.StreamConfig{
-			Name:     getDLQStreamName(p.Spec.ID),
-			MaxAge:   limits.MaxAge,
-			MaxBytes: limits.MaxBytes,
-			MaxMsgs:  limits.MaxMsgs,
+			Name: getDLQStreamName(p.Spec.ID),
 		},
 		Streams: make([]nats.StreamConfig, 0, len(graphConfig.Nodes)),
 	}

--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -11,6 +11,15 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/pipelinegraph"
 )
 
+// streamLimits bundles the NATS stream capacity parameters that travel together
+// through the plan-building helpers.
+type streamLimits struct {
+	MaxAge   time.Duration
+	MaxBytes int64
+	MaxMsgs  int64
+	Discard  jetstream.DiscardPolicy
+}
+
 type natsJoinKVStorePlan struct {
 	Name string
 	TTL  time.Duration
@@ -38,14 +47,20 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 		}
 	}
 
-	maxAge, maxBytes := r.NATSClient.DefaultStreamLimits()
+	defaultMaxAge, defaultMaxBytes, defaultMaxMsgs := r.NATSClient.DefaultStreamLimits()
+	limits := streamLimits{MaxAge: defaultMaxAge, MaxBytes: defaultMaxBytes, MaxMsgs: defaultMaxMsgs}
 	if p.Spec.Resources != nil && p.Spec.Resources.Nats != nil && p.Spec.Resources.Nats.Stream != nil {
 		s := p.Spec.Resources.Nats.Stream
 		if s.MaxAge.Duration != 0 {
-			maxAge = s.MaxAge.Duration
+			limits.MaxAge = s.MaxAge.Duration
 		}
 		if !s.MaxBytes.IsZero() {
-			maxBytes = s.MaxBytes.Value()
+			limits.MaxBytes = s.MaxBytes.Value()
+		}
+		if s.MaxMsgs != 0 {
+			// 0 is the Go zero-value (field omitted in YAML) — treat as "use operator default".
+			// NATS considers both 0 and -1 unlimited, so any non-zero value here is intentional.
+			limits.MaxMsgs = s.MaxMsgs
 		}
 	}
 
@@ -62,8 +77,9 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 	plan := natsResourcePlan{
 		DLQStream: nats.StreamConfig{
 			Name:     getDLQStreamName(p.Spec.ID),
-			MaxAge:   maxAge,
-			MaxBytes: maxBytes,
+			MaxAge:   limits.MaxAge,
+			MaxBytes: limits.MaxBytes,
+			MaxMsgs:  limits.MaxMsgs,
 		},
 		Streams: make([]nats.StreamConfig, 0, len(graphConfig.Nodes)),
 	}
@@ -73,11 +89,11 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 
 		switch node.Type {
 		case pipelinegraph.NodeTypeJoin:
-			nodePlan, err = buildJoinNodePlan(graph, node, p.Spec.Join, maxAge, maxBytes)
+			nodePlan, err = buildJoinNodePlan(graph, node, p.Spec.Join, limits)
 		case pipelinegraph.NodeTypeIngestor, pipelinegraph.NodeTypeDedup:
-			nodePlan, err = buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardNew)
+			nodePlan, err = buildNodePlan(graph, node, limits.withDiscard(jetstream.DiscardNew))
 		case pipelinegraph.NodeTypeOTLPSource:
-			nodePlan, err = buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardOld)
+			nodePlan, err = buildNodePlan(graph, node, limits.withDiscard(jetstream.DiscardOld))
 		// sink doesn't have output
 		default:
 			continue
@@ -98,20 +114,19 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 	return plan, nil
 }
 
-func buildNodePlan(
-	graph *pipelinegraph.Graph,
-	node pipelinegraph.NodeConfig,
-	maxAge time.Duration,
-	maxBytes int64,
-	discard jetstream.DiscardPolicy,
-) (natsNodePlan, error) {
+func (l streamLimits) withDiscard(d jetstream.DiscardPolicy) streamLimits {
+	l.Discard = d
+	return l
+}
+
+func buildNodePlan(graph *pipelinegraph.Graph, node pipelinegraph.NodeConfig, lim streamLimits) (natsNodePlan, error) {
 	output, err := graph.GetOutput(node.ID)
 	if err != nil {
 		return natsNodePlan{}, fmt.Errorf("resolve output for node %s: %w", node.ID, err)
 	}
 
 	return natsNodePlan{
-		Streams: buildOutputStreams(output, maxAge, maxBytes, discard),
+		Streams: buildOutputStreams(output, lim),
 	}, nil
 }
 
@@ -119,10 +134,9 @@ func buildJoinNodePlan(
 	graph *pipelinegraph.Graph,
 	node pipelinegraph.NodeConfig,
 	join etlv1alpha1.Join,
-	maxAge time.Duration,
-	maxBytes int64,
+	lim streamLimits,
 ) (natsNodePlan, error) {
-	producerPlan, err := buildNodePlan(graph, node, maxAge, maxBytes, jetstream.DiscardNew)
+	producerPlan, err := buildNodePlan(graph, node, lim.withDiscard(jetstream.DiscardNew))
 	if err != nil {
 		return natsNodePlan{}, err
 	}
@@ -157,20 +171,16 @@ func buildJoinNodePlan(
 	}, nil
 }
 
-func buildOutputStreams(
-	output pipelinegraph.OutputBinding,
-	maxAge time.Duration,
-	maxBytes int64,
-	discard jetstream.DiscardPolicy,
-) []nats.StreamConfig {
+func buildOutputStreams(output pipelinegraph.OutputBinding, lim streamLimits) []nats.StreamConfig {
 	streams := make([]nats.StreamConfig, 0, len(output.Streams))
 	for _, stream := range output.Streams {
 		streams = append(streams, nats.StreamConfig{
 			Name:     stream.Name,
 			Subjects: stream.Subjects,
-			MaxAge:   maxAge,
-			MaxBytes: maxBytes,
-			Discard:  discard,
+			MaxAge:   lim.MaxAge,
+			MaxBytes: lim.MaxBytes,
+			MaxMsgs:  lim.MaxMsgs,
+			Discard:  lim.Discard,
 		})
 	}
 	return streams

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -400,3 +400,119 @@ func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildNATSResourcePlanMaxMsgs verifies that MaxMsgs from pipeline resources overrides
+// the operator default and is applied to all streams in the plan, including the DLQ.
+func TestBuildNATSResourcePlanMaxMsgs(t *testing.T) {
+	t.Parallel()
+
+	const customMaxMsgs = int64(500_000)
+
+	reconciler := &PipelineReconciler{NATSClient: &nats.NATSClient{}}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-maxmsgs",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "events"},
+				},
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Nats: &etlv1alpha1.NatsResources{
+					Stream: &etlv1alpha1.NatsStreamResources{
+						MaxMsgs: customMaxMsgs,
+					},
+				},
+			},
+		},
+	}
+
+	plan, err := reconciler.buildNATSResourcePlan(pipeline)
+	if err != nil {
+		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
+	}
+
+	if plan.DLQStream.MaxMsgs != customMaxMsgs {
+		t.Errorf("DLQ stream MaxMsgs = %d, want %d", plan.DLQStream.MaxMsgs, customMaxMsgs)
+	}
+	for _, s := range plan.Streams {
+		if s.MaxMsgs != customMaxMsgs {
+			t.Errorf("stream %s MaxMsgs = %d, want %d", s.Name, s.MaxMsgs, customMaxMsgs)
+		}
+	}
+}
+
+// TestBuildNATSResourcePlanMaxMsgsDefault verifies that when MaxMsgs is not set in pipeline
+// resources, the operator-level default (zero for an empty NATSClient) is used.
+func TestBuildNATSResourcePlanMaxMsgsDefault(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{NATSClient: &nats.NATSClient{}}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-maxmsgs-default",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "events"},
+				},
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+		},
+	}
+
+	plan, err := reconciler.buildNATSResourcePlan(pipeline)
+	if err != nil {
+		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
+	}
+
+	// NATSClient zero value has maxMsgs=0; plan should carry that through unchanged.
+	if plan.DLQStream.MaxMsgs != 0 {
+		t.Errorf("DLQ stream MaxMsgs = %d, want 0 (operator default)", plan.DLQStream.MaxMsgs)
+	}
+	for _, s := range plan.Streams {
+		if s.MaxMsgs != 0 {
+			t.Errorf("stream %s MaxMsgs = %d, want 0 (operator default)", s.Name, s.MaxMsgs)
+		}
+	}
+}
+
+// TestBuildNATSResourcePlanMaxMsgsZeroNotOverride verifies that MaxMsgs=0 in pipeline
+// resources does not override the operator default. Both 0 and -1 mean unlimited in NATS,
+// so 0 is the natural "not configured" zero-value and must not clobber the operator default.
+func TestBuildNATSResourcePlanMaxMsgsZeroNotOverride(t *testing.T) {
+	t.Parallel()
+
+	reconciler := &PipelineReconciler{NATSClient: &nats.NATSClient{}}
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-maxmsgs-zero",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "events"},
+				},
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Nats: &etlv1alpha1.NatsResources{
+					Stream: &etlv1alpha1.NatsStreamResources{
+						MaxMsgs: 0, // explicitly zero — should not override
+					},
+				},
+			},
+		},
+	}
+
+	plan, err := reconciler.buildNATSResourcePlan(pipeline)
+	if err != nil {
+		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
+	}
+
+	// MaxMsgs=0 is treated as "not set"; operator default (0 for empty client) is preserved.
+	if plan.DLQStream.MaxMsgs != 0 {
+		t.Errorf("DLQ stream MaxMsgs = %d, want 0", plan.DLQStream.MaxMsgs)
+	}
+}

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -49,11 +49,8 @@ func TestBuildNATSResourcePlanJoinless(t *testing.T) {
 	}
 
 	hash := generatePipelineHash(pipeline.Spec.ID)
-	wantDLQ := nats.StreamConfig{
-		Name:     getDLQStreamName(pipeline.Spec.ID),
-		MaxAge:   5 * time.Minute,
-		MaxBytes: 42,
-	}
+	// DLQ has no capacity limits regardless of pipeline resource config.
+	wantDLQ := nats.StreamConfig{Name: getDLQStreamName(pipeline.Spec.ID)}
 	if !reflect.DeepEqual(plan.DLQStream, wantDLQ) {
 		t.Fatalf("plan.DLQStream = %#v, want %#v", plan.DLQStream, wantDLQ)
 	}
@@ -355,7 +352,7 @@ func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("DLQ stream has DiscardOld", func(t *testing.T) {
+	t.Run("DLQ stream has no limits and DiscardOld default", func(t *testing.T) {
 		t.Parallel()
 		pipeline := etlv1alpha1.Pipeline{
 			Spec: etlv1alpha1.PipelineSpec{
@@ -373,8 +370,10 @@ func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("buildNATSResourcePlan() error: %v", err)
 		}
-		if plan.DLQStream.Discard != jetstream.DiscardOld {
-			t.Errorf("DLQ stream: Discard = %v, want DiscardOld", plan.DLQStream.Discard)
+		// DLQ has no capacity limits — all zero-values mean unlimited in NATS.
+		wantDLQ := nats.StreamConfig{Name: getDLQStreamName(pipeline.Spec.ID)}
+		if !reflect.DeepEqual(plan.DLQStream, wantDLQ) {
+			t.Errorf("DLQ stream = %#v, want %#v", plan.DLQStream, wantDLQ)
 		}
 	})
 
@@ -434,8 +433,10 @@ func TestBuildNATSResourcePlanMaxMsgs(t *testing.T) {
 		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
 	}
 
-	if plan.DLQStream.MaxMsgs != customMaxMsgs {
-		t.Errorf("DLQ stream MaxMsgs = %d, want %d", plan.DLQStream.MaxMsgs, customMaxMsgs)
+	// DLQ has no limits regardless of pipeline resources config.
+	wantDLQ := nats.StreamConfig{Name: getDLQStreamName(pipeline.Spec.ID)}
+	if !reflect.DeepEqual(plan.DLQStream, wantDLQ) {
+		t.Errorf("DLQ stream = %#v, want %#v", plan.DLQStream, wantDLQ)
 	}
 	for _, s := range plan.Streams {
 		if s.MaxMsgs != customMaxMsgs {
@@ -468,9 +469,10 @@ func TestBuildNATSResourcePlanMaxMsgsDefault(t *testing.T) {
 		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
 	}
 
-	// NATSClient zero value has maxMsgs=0; plan should carry that through unchanged.
-	if plan.DLQStream.MaxMsgs != 0 {
-		t.Errorf("DLQ stream MaxMsgs = %d, want 0 (operator default)", plan.DLQStream.MaxMsgs)
+	// DLQ always has no limits.
+	wantDLQ := nats.StreamConfig{Name: getDLQStreamName(pipeline.Spec.ID)}
+	if !reflect.DeepEqual(plan.DLQStream, wantDLQ) {
+		t.Errorf("DLQ stream = %#v, want %#v", plan.DLQStream, wantDLQ)
 	}
 	for _, s := range plan.Streams {
 		if s.MaxMsgs != 0 {
@@ -511,8 +513,9 @@ func TestBuildNATSResourcePlanMaxMsgsZeroNotOverride(t *testing.T) {
 		t.Fatalf("buildNATSResourcePlan() returned error: %v", err)
 	}
 
-	// MaxMsgs=0 is treated as "not set"; operator default (0 for empty client) is preserved.
-	if plan.DLQStream.MaxMsgs != 0 {
-		t.Errorf("DLQ stream MaxMsgs = %d, want 0", plan.DLQStream.MaxMsgs)
+	// DLQ always has no limits, regardless of resource configuration.
+	wantDLQ := nats.StreamConfig{Name: getDLQStreamName(pipeline.Spec.ID)}
+	if !reflect.DeepEqual(plan.DLQStream, wantDLQ) {
+		t.Errorf("DLQ stream = %#v, want %#v", plan.DLQStream, wantDLQ)
 	}
 }

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -16,6 +16,10 @@ const JSErrCodeStreamRetentionPolicyChange jetstream.ErrorCode = 10052
 
 const DefaultStreamMaxAge = 168 * time.Hour       // 7 days
 const DefaultStreamMaxBytes = int64(107374182400) // 100GB
+// DefaultStreamMaxMsgs is set to ~2.5x the dedup consumer's default MaxAckPending
+// (DefaultDedupComponentBatchSize=50k * 4 = 200k), giving ~6s of headroom at 80k RPS
+// before back-pressure activates.
+const DefaultStreamMaxMsgs = int64(500_000)
 
 // ParseRetentionPolicy parses a string retention policy name to jetstream.RetentionPolicy
 // Valid values: "WorkQueue", "Limits", "Interest"
@@ -47,6 +51,7 @@ type Config struct {
 	URL                string
 	MaxAge             time.Duration
 	MaxBytes           int64
+	MaxMsgs            int64
 	Retention          jetstream.RetentionPolicy
 	AllowDirect        bool
 	AllowAtomicPublish bool
@@ -57,6 +62,7 @@ type NATSClient struct {
 	js                 jetstream.JetStream
 	maxAge             time.Duration
 	maxBytes           int64
+	maxMsgs            int64
 	retention          jetstream.RetentionPolicy
 	allowDirect        bool
 	allowAtomicPublish bool
@@ -111,6 +117,7 @@ func New(ctx context.Context, cfg Config) (*NATSClient, error) {
 		js:                 js,
 		maxAge:             cfg.MaxAge,
 		maxBytes:           cfg.MaxBytes,
+		maxMsgs:            cfg.MaxMsgs,
 		retention:          cfg.Retention,
 		allowDirect:        cfg.AllowDirect,
 		allowAtomicPublish: cfg.AllowAtomicPublish,
@@ -123,12 +130,13 @@ type StreamConfig struct {
 	Subjects []string // if empty, defaults to []string{Name + ".*"}
 	MaxAge   time.Duration
 	MaxBytes int64
+	MaxMsgs  int64
 	Discard  jetstream.DiscardPolicy
 }
 
 // DefaultStreamLimits returns the operator-level default stream limits.
-func (n *NATSClient) DefaultStreamLimits() (time.Duration, int64) {
-	return n.maxAge, n.maxBytes
+func (n *NATSClient) DefaultStreamLimits() (time.Duration, int64, int64) {
+	return n.maxAge, n.maxBytes, n.maxMsgs
 }
 
 // CreateOrUpdateStream creates or updates a NATS stream using the provided StreamConfig.
@@ -146,6 +154,7 @@ func (n *NATSClient) CreateOrUpdateStream(ctx context.Context, cfg StreamConfig)
 
 		MaxAge:   cfg.MaxAge,
 		MaxBytes: cfg.MaxBytes,
+		MaxMsgs:  cfg.MaxMsgs,
 		Discard:  cfg.Discard,
 
 		Retention:          n.retention,


### PR DESCRIPTION
## Summary

- Adds `MaxMsgs int64` to `NatsStreamResources` CRD field so pipelines can cap NATS stream message count alongside the existing `MaxAge`/`MaxBytes` limits
- Default is `500_000` (~2.5× the dedup consumer's `MaxAckPending` of 200k at default batch size, giving ~6s buffer headroom at 80k RPS before `DiscardNew` activates)
- NATS treats both `0` and `-1` as unlimited; `0` is the Go zero-value used as "not set, use operator default" — any non-zero value (including `-1`) is forwarded as-is
- Introduces `streamLimits` struct to bundle the four stream capacity params (`MaxAge`, `MaxBytes`, `MaxMsgs`, `Discard`), replacing the flat arg lists in `buildNodePlan` / `buildJoinNodePlan` / `buildOutputStreams`
- Adds `--nats-max-stream-msgs` / `NATS_MAX_STREAM_MSGS` operator flag (default `1_000_000`)
- CRD updated in both `config/crd/bases/` and `charts/glassflow-operator/templates/`

## Test plan

- [ ] `go test ./internal/controller/... -run TestBuildNATSResourcePlan` — all 9 plan tests pass
- [ ] `go build ./...` — clean
- [ ] `go build ./test/...` — e2e compiles

Closes ETL-1020