### PR TITLE
fix: CVE-2026-33815

### DIFF
--- a/.github/workflows/test-operator.yml
+++ b/.github/workflows/test-operator.yml
@@ -16,9 +16,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.63.4
+          version: v2.6
 
   test-operator:
     name: Test Operator

--- a/.github/workflows/test-operator.yml
+++ b/.github/workflows/test-operator.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true
@@ -11,8 +13,6 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
     - govet
     - ineffassign
     - lll
@@ -23,11 +23,13 @@ linters:
     - staticcheck
     - unconvert
     - unparam
+    - unused
   settings:
     revive:
       rules:
         - name: comment-spacings
   exclusions:
+    generated: lax
     rules:
       - path: "api/*"
         linters:
@@ -37,4 +39,7 @@ linters:
           - dupl
           - lll
 
-version: "2"
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,12 +2,6 @@ run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  # restore some of the defaults
-  # (fill in the rest as needed)
-
 linters:
   enable:
     - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,22 @@ run:
   timeout: 5m
   allow-parallel-runners: true
 
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+  exclude-rules:
+    - path: "api/*"
+      linters:
+        - lll
+    - path: "internal/*"
+      linters:
+        - dupl
+        - lll
 linters:
+  disable-all: true
   enable:
     - dupl
     - errcheck
@@ -10,6 +25,9 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
     - govet
     - ineffassign
     - lll
@@ -18,7 +36,12 @@ linters:
     - prealloc
     - revive
     - staticcheck
+    - typecheck
     - unconvert
     - unparam
+    - unused
 
-version: "2"
+linters-settings:
+  revive:
+    rules:
+      - name: comment-spacings

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,21 +2,6 @@ run:
   timeout: 5m
   allow-parallel-runners: true
 
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
-
 linters:
   default: none
   enable:
@@ -38,10 +23,18 @@ linters:
     - staticcheck
     - unconvert
     - unparam
-
-linters-settings:
-  revive:
+  settings:
+    revive:
+      rules:
+        - name: comment-spacings
+  exclusions:
     rules:
-      - name: comment-spacings
+      - path: "api/*"
+        linters:
+          - lll
+      - path: "internal/*"
+        linters:
+          - dupl
+          - lll
 
 version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,9 @@ issues:
       linters:
         - dupl
         - lll
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - dupl
     - errcheck
@@ -27,7 +28,6 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -36,12 +36,12 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
-    - unused
 
 linters-settings:
   revive:
     rules:
       - name: comment-spacings
+
+version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - ginkgolinter
     - goconst
     - gocyclo
-    - gofmt
     - goimports
     - gosimple
     - govet
@@ -24,6 +23,3 @@ linters:
     - unconvert
     - unparam
     - unused
-
-
-version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,24 +4,23 @@ run:
 
 linters:
   enable:
-    - dupl
-    - errcheck
-    - copyloopvar
-    - ginkgolinter
-    - goconst
-    - gocyclo
-    - goimports
-    - gosimple
-    - govet
-    - ineffassign
+    - duple
+    - err check
+    - laparoscopy
+    - ginkgo linter
+    - icons
+    - go cyclo
+    - simple
+    - govt
+    - assignees
     - lll
     - misspell
-    - nakedret
-    - prealloc
+    - nakedest
+    - preallocate
     - revive
-    - staticcheck
+    - static-check
     - unconvert
-    - unparam
+    - param
     - unused
 
 version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,3 +45,5 @@ linters-settings:
   revive:
     rules:
       - name: comment-spacings
+
+version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,3 +23,5 @@ linters:
     - unconvert
     - unparam
     - unused
+
+version: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,23 +4,21 @@ run:
 
 linters:
   enable:
-    - duple
-    - err check
-    - laparoscopy
-    - ginkgo linter
-    - icons
-    - go cyclo
-    - simple
-    - govt
-    - assignees
+    - dupl
+    - errcheck
+    - copyloopvar
+    - ginkgolinter
+    - goconst
+    - gocyclo
+    - govet
+    - ineffassign
     - lll
     - misspell
-    - nakedest
-    - preallocate
+    - nakedret
+    - prealloc
     - revive
-    - static-check
+    - staticcheck
     - unconvert
-    - param
-    - unused
+    - unparam
 
 version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,4 +24,4 @@ linters:
     - unparam
     - unused
 
-version: 2
+version: "2"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,19 +5,10 @@ run:
 issues:
   # don't skip warning about doc comments
   # don't exclude the default set of lint
-  exclude-use-default: false
   # restore some of the defaults
   # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
+
 linters:
-  disable-all: true
   enable:
     - dupl
     - errcheck
@@ -40,9 +31,5 @@ linters:
     - unparam
     - unused
 
-linters-settings:
-  revive:
-    rules:
-      - name: comment-spacings
 
 version: "2"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/glassflow/glassflow-etl-k8s-operator
 
-go 1.23.0
+go 1.25.0
 
 godebug default=go1.23
 
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/nats-io/nats.go v1.48.0
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1
@@ -79,12 +79,12 @@ require (
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.34.0 // indirect
-	golang.org/x/text v0.28.0 // indirect
+	golang.org/x/text v0.29.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
-	golang.org/x/tools v0.35.0 // indirect
+	golang.org/x/tools v0.36.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/nats-io/nats.go v1.48.0
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.9.2
+	github.com/jackc/pgx/v5 v5.9.0
 	github.com/nats-io/nats.go v1.48.0
 	github.com/onsi/ginkgo/v2 v2.21.0
 	github.com/onsi/gomega v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
-github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
+github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
 github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
@@ -189,8 +187,7 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
-golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -201,8 +198,6 @@ golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
 golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
-golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
 golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
@@ -211,8 +206,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
-golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
 golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -189,6 +191,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
 golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -200,6 +203,8 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
 golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
+golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
+golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
 golang.org/x/time v0.7.0 h1:ntUhktv3OPE6TgYxXWv9vKvUSJyIFJlyohwbkEwPrKQ=
 golang.org/x/time v0.7.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -208,6 +213,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
 golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -31,7 +31,7 @@ func (c *helmUninstallTestClient) Get(_ context.Context, key client.ObjectKey, o
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	stored, exists := c.objects[types.NamespacedName(key)]
 	if !exists {
 		return nil
 	}

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -31,7 +31,7 @@ func (c *helmUninstallTestClient) Get(_ context.Context, key client.ObjectKey, o
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stored, exists := c.objects[key]
+	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
 	if !exists {
 		return nil
 	}

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -31,7 +31,7 @@ func (c *helmUninstallTestClient) Get(_ context.Context, key client.ObjectKey, o
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	stored, exists := c.objects[key]
 	if !exists {
 		return nil
 	}

--- a/internal/controller/helm_uninstall_test.go
+++ b/internal/controller/helm_uninstall_test.go
@@ -31,7 +31,7 @@ func (c *helmUninstallTestClient) Get(_ context.Context, key client.ObjectKey, o
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	stored, exists := c.objects[types.NamespacedName(key)]
+	stored, exists := c.objects[key]
 	if !exists {
 		return nil
 	}

--- a/internal/controller/helpers_config_test.go
+++ b/internal/controller/helpers_config_test.go
@@ -138,11 +138,11 @@ func TestGetComponentEncryptionHelpersUseConfig(t *testing.T) {
 	if vol.Name != "encryption-key" {
 		t.Fatalf("unexpected encryption volume name: %s", vol.Name)
 	}
-	if vol.VolumeSource.Secret == nil {
+	if vol.Secret == nil {
 		t.Fatalf("expected secret volume source")
 	}
-	if vol.VolumeSource.Secret.SecretName != constants.ComponentEncryptionSecretName {
-		t.Fatalf("unexpected encryption secret name: %s", vol.VolumeSource.Secret.SecretName)
+	if vol.Secret.SecretName != constants.ComponentEncryptionSecretName {
+		t.Fatalf("unexpected encryption secret name: %s", vol.Secret.SecretName)
 	}
 
 	mount, ok := reconcilerEnabled.getComponentEncryptionVolumeMount()

--- a/internal/controller/k8s_resources_test.go
+++ b/internal/controller/k8s_resources_test.go
@@ -91,7 +91,7 @@ func TestCleanupDisabledDedupPVCsSkipsEnabledStreams(t *testing.T) {
 
 	// PVC should still exist — dedup is enabled, so it should not be deleted.
 	var remaining v1.PersistentVolumeClaim
-	if err = reconciler.Client.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: pvcName}, &remaining); err != nil {
+	if err = reconciler.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: pvcName}, &remaining); err != nil {
 		t.Fatalf("expected PVC %s to still exist, got: %v", pvcName, err)
 	}
 }

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -341,7 +341,7 @@ func (c *operationTestClient) Get(_ context.Context, key client.ObjectKey, obj c
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	stored, exists := c.objects[types.NamespacedName(key)]
+	stored, exists := c.objects[key]
 	if !exists {
 		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
 	}

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -341,7 +341,7 @@ func (c *operationTestClient) Get(_ context.Context, key client.ObjectKey, obj c
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	stored, exists := c.objects[key]
+	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
 	if !exists {
 		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
 	}

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -341,7 +341,7 @@ func (c *operationTestClient) Get(_ context.Context, key client.ObjectKey, obj c
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	stored, exists := c.objects[types.NamespacedName(key)]
 	if !exists {
 		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
 	}

--- a/internal/controller/operations_test.go
+++ b/internal/controller/operations_test.go
@@ -341,7 +341,7 @@ func (c *operationTestClient) Get(_ context.Context, key client.ObjectKey, obj c
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	stored, exists := c.objects[types.NamespacedName{Name: key.Name, Namespace: key.Namespace}]
+	stored, exists := c.objects[key]
 	if !exists {
 		return apierrors.NewNotFound(schema.GroupResource{Group: "etl.glassflow.io", Resource: "pipelines"}, key.Name)
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"os/exec"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2" //nolint:golint,revive,staticcheck
+	. "github.com/onsi/ginkgo/v2" //nolint:revive,staticcheck
 )
 
 const (


### PR DESCRIPTION
1. ch-etl uses Go 1.25, match operator to build using same Go version
2. new pgx lib with fix for CVE requires min version Go 1.25
3. Refactor code for linter errors