### PR TITLE
feat: e2e tests for pipeline lifecycle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM golang:1.25 AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd/ cmd/
+COPY api/ api/
+COPY internal/ internal/
+COPY pkg/ pkg/
+
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o manager cmd/main.go
+
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY ./bin/manager .
+COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build --load -t ${IMG} .
 
+.PHONY: docker-build-noop
+docker-build-noop: ## Build the no-op component image for e2e tests.
+	$(CONTAINER_TOOL) build --load -t glassflow-noop-component:test -f test/docker/Dockerfile.noop .
+
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
@@ -171,6 +175,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+
+.PHONY: deploy-e2e
+deploy-e2e: manifests kustomize ## Deploy controller with e2e overlay (noop component images, no postgres required).
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/e2e | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -574,7 +574,8 @@ func main() {
 	// Initialize PostgreSQL storage (optional — omit to run without pipeline-delete persistence)
 	var postgresStorage *postgresstorage.PostgresStorage
 	if postgresDSN == "" {
-		setupLog.Info("postgres DSN not provided — pipeline status will not be persisted; delete operations will skip postgres cleanup")
+		setupLog.Info("postgres DSN not provided — pipeline status will not be persisted;" +
+			" delete operations will skip postgres cleanup")
 	} else {
 		postgresStorage, err = postgresstorage.NewPostgres(ctx, postgresOperatorDSN, logger)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -572,18 +571,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize PostgreSQL storage (required)
+	// Initialize PostgreSQL storage (optional — omit to run without pipeline-delete persistence)
+	var postgresStorage *postgresstorage.PostgresStorage
 	if postgresDSN == "" {
-		setupLog.Error(errors.New("postgres DSN is required"), "postgres DSN not provided")
-		os.Exit(1)
+		setupLog.Info("postgres DSN not provided — pipeline status will not be persisted; delete operations will skip postgres cleanup")
+	} else {
+		postgresStorage, err = postgresstorage.NewPostgres(ctx, postgresOperatorDSN, logger)
+		if err != nil {
+			setupLog.Error(err, "unable to connect to postgres")
+			os.Exit(1)
+		}
+		setupLog.Info("postgres storage initialized")
 	}
-
-	postgresStorage, err := postgresstorage.NewPostgres(ctx, postgresOperatorDSN, logger)
-	if err != nil {
-		setupLog.Error(err, "unable to connect to postgres")
-		os.Exit(1)
-	}
-	setupLog.Info("postgres storage initialized")
 
 	notificationsConfig := opnotifications.DefaultConfig().
 		WithEnabled(notificationsEnabledBool)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,15 @@ import (
 )
 
 // getEnvOrDefault returns the value of the environment variable if set, otherwise returns the default value
+// nilStorage converts a *postgresstorage.PostgresStorage to the controller's pipelineStorage
+// interface, returning a true nil interface when s is nil to avoid the nil-pointer-in-interface trap.
+func nilStorage(s *postgresstorage.PostgresStorage) controller.PipelineStorage {
+	if s == nil {
+		return nil
+	}
+	return s
+}
+
 func getEnvOrDefault(key, defaultValue string) string {
 	if value := os.Getenv(key); value != "" {
 		return value
@@ -702,7 +711,7 @@ func main() {
 		Scheme:           mgr.GetScheme(),
 		Meter:            meter,
 		NATSClient:       natsClient,
-		PostgresStorage:  postgresStorage,
+		PostgresStorage:  nilStorage(postgresStorage),
 		Config:           reconcilerConfig,
 		UsageStatsClient: usageStatsClient,
 	}).SetupWithManager(mgr); err != nil {

--- a/config/crd/bases/etl.glassflow.io_pipelines.yaml
+++ b/config/crd/bases/etl.glassflow.io_pipelines.yaml
@@ -369,9 +369,9 @@ spec:
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                           maxMsgs:
-                            description: MaxMsgs sets the maximum number of messages
-                              the stream will store. NATS treats both 0 and -1 as unlimited;
-                              omitting this field (zero value) means use the operator default.
+                            description: |-
+                              MaxMsgs sets the maximum number of messages the stream will store.
+                              NATS treats both 0 and -1 as unlimited; omitting this field (zero value) means use the operator default.
                             format: int64
                             type: integer
                         type: object

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+- ../default
+
+patches:
+- path: manager_env_patch.yaml
+  target:
+    kind: Deployment
+    name: controller-manager

--- a/config/e2e/manager_env_patch.yaml
+++ b/config/e2e/manager_env_patch.yaml
@@ -36,7 +36,7 @@ spec:
         - name: PIPELINES_NAMESPACE_AUTO
           value: "true"
         - name: RECONCILE_TIMEOUT
-          value: "3m"
+          value: "10m"
         - name: OBSERVABILITY_LOGS_ENABLED
           value: "false"
         - name: OBSERVABILITY_METRICS_ENABLED

--- a/config/e2e/manager_env_patch.yaml
+++ b/config/e2e/manager_env_patch.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: INGESTOR_IMAGE
+          value: "glassflow-noop-component:test"
+        - name: JOIN_IMAGE
+          value: "glassflow-noop-component:test"
+        - name: SINK_IMAGE
+          value: "glassflow-noop-component:test"
+        - name: DEDUP_IMAGE
+          value: "glassflow-noop-component:test"
+        - name: INGESTOR_PULL_POLICY
+          value: "Never"
+        - name: JOIN_PULL_POLICY
+          value: "Never"
+        - name: SINK_PULL_POLICY
+          value: "Never"
+        - name: DEDUP_PULL_POLICY
+          value: "Never"
+        - name: NATS_ADDR
+          value: "nats://nats.default.svc.cluster.local:4222"
+        - name: NATS_OP_ADDR
+          value: "nats://nats.default.svc.cluster.local:4222"
+        - name: NATS_MAX_STREAM_AGE
+          value: "24h"
+        - name: NATS_MAX_STREAM_BYTES
+          value: "1073741824"
+        - name: PIPELINES_NAMESPACE_AUTO
+          value: "true"
+        - name: RECONCILE_TIMEOUT
+          value: "3m"
+        - name: OBSERVABILITY_LOGS_ENABLED
+          value: "false"
+        - name: OBSERVABILITY_METRICS_ENABLED
+          value: "false"
+        - name: NOTIFICATIONS_ENABLED
+          value: "false"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,12 +38,14 @@ rules:
 - apiGroups:
   - apps
   resources:
-  - deployments
+  - statefulsets
   verbs:
   - create
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - etl.glassflow.io

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -83,7 +83,6 @@ type PipelineStorage interface {
 	) error
 }
 
-
 // -------------------------------------------------------------------------------------------------------------------
 
 // PipelineReconciler reconciles a Pipeline object

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -174,6 +174,7 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 	// Check if pipeline is already running
 	if p.Status == etlv1alpha1.PipelineStatus(models.PipelineStatusRunning) {
 		log.Info("pipeline already running", "pipeline_id", p.Spec.ID)
+		r.clearOperationAnnotationAndStatus(ctx, log, &p, constants.PipelineCreateAnnotation, models.PipelineStatusRunning, true)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -78,7 +78,9 @@ var pipelineOperationPredicate = predicate.Funcs{
 // PipelineStorage is the subset of postgres.PostgresStorage used by the controller.
 type PipelineStorage interface {
 	DeletePipeline(ctx context.Context, pipelineID string) error
-	UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string, reason string) error
+	UpdatePipelineStatus(
+		ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string, reason string,
+	) error
 }
 
 
@@ -174,7 +176,8 @@ func (r *PipelineReconciler) reconcileCreate(ctx context.Context, log logr.Logge
 	// Check if pipeline is already running
 	if p.Status == etlv1alpha1.PipelineStatus(models.PipelineStatusRunning) {
 		log.Info("pipeline already running", "pipeline_id", p.Spec.ID)
-		r.clearOperationAnnotationAndStatus(ctx, log, &p, constants.PipelineCreateAnnotation, models.PipelineStatusRunning, true)
+		r.clearOperationAnnotationAndStatus(
+			ctx, log, &p, constants.PipelineCreateAnnotation, models.PipelineStatusRunning, true)
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -75,11 +75,12 @@ var pipelineOperationPredicate = predicate.Funcs{
 	},
 }
 
-// pipelineStorage is the subset of postgres.PostgresStorage used by the controller.
-type pipelineStorage interface {
+// PipelineStorage is the subset of postgres.PostgresStorage used by the controller.
+type PipelineStorage interface {
 	DeletePipeline(ctx context.Context, pipelineID string) error
 	UpdatePipelineStatus(ctx context.Context, pipelineID string, status models.PipelineStatus, errors []string, reason string) error
 }
+
 
 // -------------------------------------------------------------------------------------------------------------------
 
@@ -89,7 +90,7 @@ type PipelineReconciler struct {
 	Scheme           *runtime.Scheme
 	Meter            *observability.Meter
 	NATSClient       *nats.NATSClient
-	PostgresStorage  pipelineStorage
+	PostgresStorage  PipelineStorage
 	Config           ReconcilerConfig
 	UsageStatsClient *usagestats.Client
 }
@@ -116,7 +117,7 @@ func (r *PipelineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;delete
-// +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;delete
 
 // For more details, check Reconcile and its Result here:

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -343,12 +343,13 @@ func (r *PipelineReconciler) reconcileDelete(ctx context.Context, log logr.Logge
 	}
 
 	// Clean up pipeline configuration from PostgreSQL
-	err = r.PostgresStorage.DeletePipeline(ctx, p.Spec.ID)
-	if err != nil {
-		log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID, "error", err)
-		// Don't return error here - we're in force cleanup mode
-	} else {
-		log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID)
+	if r.PostgresStorage != nil {
+		err = r.PostgresStorage.DeletePipeline(ctx, p.Spec.ID)
+		if err != nil {
+			log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID, "error", err)
+		} else {
+			log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", p.Spec.ID)
+		}
 	}
 
 	r.clearOperationAnnotationAndStatus(
@@ -390,10 +391,12 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 		log.Info("pipeline already stopped during helm uninstall", "pipeline_id", pipelineID)
 
 		// Delete pipeline configuration from PostgreSQL for stopped pipelines
-		if err := r.PostgresStorage.DeletePipeline(ctx, pipelineID); err != nil {
-			log.Info("failed to delete stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
-		} else {
-			log.Info("successfully deleted stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
+		if r.PostgresStorage != nil {
+			if err := r.PostgresStorage.DeletePipeline(ctx, pipelineID); err != nil {
+				log.Info("failed to delete stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
+			} else {
+				log.Info("successfully deleted stopped pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
+			}
 		}
 
 		// Remove helm uninstall annotation and finalizer to allow cleanup
@@ -435,12 +438,13 @@ func (r *PipelineReconciler) reconcileHelmUninstall(ctx context.Context, log log
 	}
 
 	// Clean up pipeline configuration from PostgreSQL
-	err = r.PostgresStorage.DeletePipeline(ctx, pipelineID)
-	if err != nil {
-		log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
-		// Don't return error here - we're in force cleanup mode
-	} else {
-		log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
+	if r.PostgresStorage != nil {
+		err = r.PostgresStorage.DeletePipeline(ctx, pipelineID)
+		if err != nil {
+			log.Info("failed to delete pipeline configuration from PostgreSQL", "pipeline_id", pipelineID, "error", err)
+		} else {
+			log.Info("successfully deleted pipeline configuration from PostgreSQL", "pipeline_id", pipelineID)
+		}
 	}
 
 	// Remove all pipeline operation annotations

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,158 +1,323 @@
-/*
-Copyright 2025.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controller
 
 import (
 	"context"
-	"time"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
 )
 
-var _ = Describe("Pipeline Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-pipeline"
+// newTestReconciler creates a PipelineReconciler configured for integration tests.
+// NATS at localhost:4222 is required; postgres is intentionally omitted.
+func newTestReconciler(nc *nats.NATSClient) *PipelineReconciler {
+	return &PipelineReconciler{
+		Client:     k8sClient,
+		Scheme:     k8sClient.Scheme(),
+		NATSClient: nc,
+		Config: ReconcilerConfig{
+			NATS: NATSSettings{ComponentAddr: "nats://nats.default.svc.cluster.local:4222"},
+			Images: ComponentImages{
+				Ingestor: "glassflow-noop-component:test",
+				Join:     "glassflow-noop-component:test",
+				Sink:     "glassflow-noop-component:test",
+				Dedup:    "glassflow-noop-component:test",
+			},
+			PullPolicies: ComponentPullPolicies{
+				Ingestor: "IfNotPresent",
+				Join:     "IfNotPresent",
+				Sink:     "IfNotPresent",
+				Dedup:    "IfNotPresent",
+			},
+			Namespaces:         PipelineNamespaces{Auto: true},
+			GlassflowNamespace: "default",
+			Observability: ComponentObservability{
+				LogsEnabled:    "false",
+				MetricsEnabled: "false",
+				OTelEndpoint:   "http://localhost:4318",
+				LogLevels:      ComponentLogLevels{Ingestor: "info", Join: "info", Sink: "info", Dedup: "info"},
+				ImageTags:      ComponentImageTags{Ingestor: "test", Join: "test", Sink: "test", Dedup: "test"},
+			},
+			DedupStorage: DedupStorageDefaults{Size: "1Gi"},
+			ResourceDefaults: ComponentResourceDefaults{
+				Ingestor: ResourceDefaults{CPURequest: "100m", CPULimit: "200m", MemoryRequest: "128Mi", MemoryLimit: "256Mi"},
+				Sink:     ResourceDefaults{CPURequest: "100m", CPULimit: "200m", MemoryRequest: "128Mi", MemoryLimit: "256Mi"},
+				Join:     ResourceDefaults{CPURequest: "100m", CPULimit: "200m", MemoryRequest: "128Mi", MemoryLimit: "256Mi"},
+				Dedup:    ResourceDefaults{CPURequest: "100m", CPULimit: "200m", MemoryRequest: "256Mi", MemoryLimit: "512Mi"},
+			},
+		},
+	}
+}
 
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default",
+// patchStatefulSetsToReady sets ReadyReplicas == Spec.Replicas for all StatefulSets
+// in the given namespace. envtest has no kubelet, so we do this manually to unblock
+// the cascade (sink → join → dedup → ingestor).
+func patchStatefulSetsToReady(ctx context.Context, g Gomega, namespace string) {
+	var stsList appsv1.StatefulSetList
+	g.Expect(k8sClient.List(ctx, &stsList, client.InNamespace(namespace))).To(Succeed())
+	for i := range stsList.Items {
+		sts := &stsList.Items[i]
+		if sts.Spec.Replicas == nil || sts.Status.ReadyReplicas == *sts.Spec.Replicas {
+			continue
 		}
-		pipeline := &etlv1alpha1.Pipeline{}
+		patch := sts.DeepCopy()
+		patch.Status.ReadyReplicas = *sts.Spec.Replicas
+		patch.Status.Replicas = *sts.Spec.Replicas
+		patch.Status.AvailableReplicas = *sts.Spec.Replicas
+		if err := k8sClient.Status().Update(ctx, patch); err != nil && !apierrors.IsConflict(err) {
+			g.Expect(err).NotTo(HaveOccurred())
+		}
+	}
+}
 
-		nc, err := nats.New(ctx, nats.Config{
-			URL:                "http://localhost:4222",
+// driveToRunning keeps reconciling (patching StatefulSet statuses each time) until
+// the pipeline status is "Running" or the Eventually timeout is reached.
+func driveToRunning(ctx context.Context, reconciler *PipelineReconciler, pipelineRef types.NamespacedName, pipelineNS string) {
+	GinkgoHelper()
+	Eventually(func(g Gomega) {
+		patchStatefulSetsToReady(ctx, g, pipelineNS)
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: pipelineRef})
+		g.Expect(err).NotTo(HaveOccurred())
+		var p etlv1alpha1.Pipeline
+		g.Expect(k8sClient.Get(ctx, pipelineRef, &p)).To(Succeed())
+		g.Expect(string(p.Status)).To(Equal("Running"))
+	}, "60s", "500ms").Should(Succeed())
+}
+
+var _ = Describe("Pipeline Controller", Ordered, func() {
+	var (
+		nc  *nats.NATSClient
+		err error
+	)
+
+	BeforeAll(func() {
+		nc, err = nats.New(ctx, nats.Config{
+			URL:                "nats://localhost:4222",
 			MaxAge:             nats.DefaultStreamMaxAge,
-			MaxBytes:           nats.DefaultStreamMaxBytes,
+			MaxBytes:           int64(10 * 1024 * 1024), // 10MB — enough for tests, avoids NATS storage limit errors
+			MaxMsgs:            int64(1000),
 			Retention:          nats.ParseRetentionPolicy("WorkQueue"),
 			AllowDirect:        true,
 			AllowAtomicPublish: true,
 		})
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "NATS must be running at localhost:4222 for integration tests")
+	})
 
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind Pipeline")
-			err := k8sClient.Get(ctx, typeNamespacedName, pipeline)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &etlv1alpha1.Pipeline{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: etlv1alpha1.PipelineSpec{
-						ID: resourceName,
-						Source: etlv1alpha1.Sources{
-							Type: "kafka",
-							Streams: []etlv1alpha1.SourceStream{
-								{
-									TopicName:   "test_topic1",
-									DedupWindow: 2 * time.Hour,
-								},
-								{
-									TopicName:   "test_topic2",
-									DedupWindow: 5 * time.Minute,
-								},
-							},
-						},
-						Join: etlv1alpha1.Join{
-							Type:    "temporal",
-							Enabled: true,
-						},
-						Sink: etlv1alpha1.Sink{
-							Type: "clickhouse",
-						},
-						Resources: &etlv1alpha1.PipelineResources{
-							Ingestor: &etlv1alpha1.IngestorResources{
-								Left:  &etlv1alpha1.ComponentResources{Replicas: ptrInt32(1)},
-								Right: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(1)},
-							},
-							Join: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(1)},
-							Sink: &etlv1alpha1.ComponentResources{Replicas: ptrInt32(1)},
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
+	Context("Simple kafka pipeline (1 ingestor, 1 sink)", func() {
+		const pipelineID = "test-simple-01"
+		pipelineRef := types.NamespacedName{Name: pipelineID, Namespace: "default"}
+		pipelineNS := "pipeline-" + pipelineID
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &etlv1alpha1.Pipeline{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance Pipeline")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &PipelineReconciler{
-				Client:     k8sClient,
-				Scheme:     k8sClient.Scheme(),
-				NATSClient: nc,
-				Config: ReconcilerConfig{
-					NATS: NATSSettings{
-						ComponentAddr: "nats://nats.default.svc.cluster.local:4222",
-					},
-					Images: ComponentImages{
-						Ingestor: "ghcr.io/glassflow/glassflow-etl-ingestor:latest",
-						Join:     "ghcr.io/glassflow/glassflow-etl-join:latest",
-						Sink:     "ghcr.io/glassflow/glassflow-etl-sink:latest",
-					},
-					PullPolicies: ComponentPullPolicies{
-						Ingestor: "IfNotPresent",
-						Join:     "IfNotPresent",
-						Sink:     "IfNotPresent",
-						Dedup:    "IfNotPresent",
-					},
-					Observability: ComponentObservability{
-						LogsEnabled:    "true",
-						MetricsEnabled: "true",
-						OTelEndpoint:   "http://otel-collector.observability.svc.cluster.local:4318",
-						LogLevels: ComponentLogLevels{
-							Ingestor: "info",
-							Join:     "info",
-							Sink:     "info",
-						},
-						ImageTags: ComponentImageTags{
-							Ingestor: "latest",
-							Join:     "latest",
-							Sink:     "latest",
-						},
-					},
-				},
+			// Clean up Pipeline CR
+			p := &etlv1alpha1.Pipeline{}
+			if err := k8sClient.Get(ctx, pipelineRef, p); err == nil {
+				// Remove finalizer to allow deletion
+				p.Finalizers = nil
+				_ = k8sClient.Update(ctx, p)
+				_ = k8sClient.Delete(ctx, p)
 			}
+			// Clean up namespace
+			ns := &v1.Namespace{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pipelineNS}, ns); err == nil {
+				_ = k8sClient.Delete(ctx, ns)
+			}
+			// Clean up NATS streams
+			_ = nc.DeleteAllPipelineStreams(ctx, generatePipelineHash(pipelineID))
+		})
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		It("creates namespace, NATS streams, StatefulSets, and Services", func() {
+			p := simplePipeline(pipelineID, 1, 1)
+			Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+			reconciler := newTestReconciler(nc)
+			driveToRunning(ctx, reconciler, pipelineRef, pipelineNS)
+
+			By("namespace exists")
+			var ns v1.Namespace
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pipelineNS}, &ns)).To(Succeed())
+
+			By("sink StatefulSet exists with 1 replica")
+			var sinkSTS appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "sink"}, &sinkSTS)).To(Succeed())
+			Expect(*sinkSTS.Spec.Replicas).To(Equal(int32(1)))
+
+			By("ingestor StatefulSet exists with 1 replica")
+			var ingSTS appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-0"}, &ingSTS)).To(Succeed())
+			Expect(*ingSTS.Spec.Replicas).To(Equal(int32(1)))
+
+			By("headless Services exist")
+			var svc v1.Service
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "sink"}, &svc)).To(Succeed())
+			Expect(svc.Spec.ClusterIP).To(Equal("None"))
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-0"}, &svc)).To(Succeed())
+
+			By("pipeline config secret exists in pipeline namespace")
+			var secret v1.Secret
+			secretName := newTestReconciler(nc).getResourceName(*p)
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: secretName}, &secret)).To(Succeed())
+			Expect(secret.Data).To(HaveKey("pipeline.json"))
+
+			By("NATS streams exist")
+			hash := generatePipelineHash(pipelineID)
+			streams, listErr := nc.ListPipelineStreams(ctx, hash)
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(streams).NotTo(BeEmpty())
+			// DLQ stream must always exist
+			dlqName := getDLQStreamName(pipelineID)
+			Expect(streams).To(ContainElement(dlqName))
+			// Ingestor output stream (1 sink replica → 1 stream)
+			ingestorStream := fmt.Sprintf("gfm-%s-ingestor-out_0", hash)
+			Expect(streams).To(ContainElement(ingestorStream))
+		})
+	})
+
+	Context("Join pipeline (2 ingestors, join, sink)", func() {
+		const pipelineID = "test-join-01"
+		pipelineRef := types.NamespacedName{Name: pipelineID, Namespace: "default"}
+		pipelineNS := "pipeline-" + pipelineID
+
+		AfterEach(func() {
+			p := &etlv1alpha1.Pipeline{}
+			if err := k8sClient.Get(ctx, pipelineRef, p); err == nil {
+				p.Finalizers = nil
+				_ = k8sClient.Update(ctx, p)
+				_ = k8sClient.Delete(ctx, p)
+			}
+			ns := &v1.Namespace{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pipelineNS}, ns); err == nil {
+				_ = k8sClient.Delete(ctx, ns)
+			}
+			_ = nc.DeleteAllPipelineStreams(ctx, generatePipelineHash(pipelineID))
+		})
+
+		It("creates 2 ingestors, join, sink StatefulSets and NATS join KV stores", func() {
+			p := joinPipeline(pipelineID, 1, 1, 1, 1)
+			Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+			reconciler := newTestReconciler(nc)
+			driveToRunning(ctx, reconciler, pipelineRef, pipelineNS)
+
+			By("sink StatefulSet exists")
+			var sts appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "sink"}, &sts)).To(Succeed())
+
+			By("join StatefulSet exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "join"}, &sts)).To(Succeed())
+
+			By("left ingestor StatefulSet exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-0"}, &sts)).To(Succeed())
+
+			By("right ingestor StatefulSet exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-1"}, &sts)).To(Succeed())
+
+			By("NATS join output stream exists")
+			hash := generatePipelineHash(pipelineID)
+			streams, listErr := nc.ListPipelineStreams(ctx, hash)
+			Expect(listErr).NotTo(HaveOccurred())
+			joinStream := fmt.Sprintf("gfm-%s-join-out_0", hash)
+			Expect(streams).To(ContainElement(joinStream))
+		})
+	})
+
+	Context("Dedup pipeline (ingestor, dedup, sink)", func() {
+		const pipelineID = "test-dedup-01"
+		pipelineRef := types.NamespacedName{Name: pipelineID, Namespace: "default"}
+		pipelineNS := "pipeline-" + pipelineID
+
+		AfterEach(func() {
+			p := &etlv1alpha1.Pipeline{}
+			if err := k8sClient.Get(ctx, pipelineRef, p); err == nil {
+				p.Finalizers = nil
+				_ = k8sClient.Update(ctx, p)
+				_ = k8sClient.Delete(ctx, p)
+			}
+			ns := &v1.Namespace{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pipelineNS}, ns); err == nil {
+				_ = k8sClient.Delete(ctx, ns)
+			}
+			_ = nc.DeleteAllPipelineStreams(ctx, generatePipelineHash(pipelineID))
+		})
+
+		It("creates ingestor, dedup, sink StatefulSets with PVC for dedup", func() {
+			p := dedupPipeline(pipelineID)
+			Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+			reconciler := newTestReconciler(nc)
+			driveToRunning(ctx, reconciler, pipelineRef, pipelineNS)
+
+			By("sink StatefulSet exists")
+			var sts appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "sink"}, &sts)).To(Succeed())
+
+			By("dedup StatefulSet exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "dedup-0"}, &sts)).To(Succeed())
+			Expect(sts.Spec.VolumeClaimTemplates).NotTo(BeEmpty(), "dedup StatefulSet must have PVC template")
+
+			By("ingestor StatefulSet exists")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-0"}, &sts)).To(Succeed())
+
+			By("NATS dedup output stream exists")
+			hash := generatePipelineHash(pipelineID)
+			streams, listErr := nc.ListPipelineStreams(ctx, hash)
+			Expect(listErr).NotTo(HaveOccurred())
+			dedupStream := fmt.Sprintf("gfm-%s-dedup-out_0", hash)
+			Expect(streams).To(ContainElement(dedupStream))
+		})
+	})
+
+	Context("Multi-replica pipeline (2 ingestors, 2 sinks)", func() {
+		const pipelineID = "test-multi-01"
+		pipelineRef := types.NamespacedName{Name: pipelineID, Namespace: "default"}
+		pipelineNS := "pipeline-" + pipelineID
+
+		AfterEach(func() {
+			p := &etlv1alpha1.Pipeline{}
+			if err := k8sClient.Get(ctx, pipelineRef, p); err == nil {
+				p.Finalizers = nil
+				_ = k8sClient.Update(ctx, p)
+				_ = k8sClient.Delete(ctx, p)
+			}
+			ns := &v1.Namespace{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pipelineNS}, ns); err == nil {
+				_ = k8sClient.Delete(ctx, ns)
+			}
+			_ = nc.DeleteAllPipelineStreams(ctx, generatePipelineHash(pipelineID))
+		})
+
+		It("creates StatefulSets with correct replica counts and 2 NATS streams", func() {
+			p := multiReplicaPipeline(pipelineID, 2)
+			Expect(k8sClient.Create(ctx, p)).To(Succeed())
+
+			reconciler := newTestReconciler(nc)
+			driveToRunning(ctx, reconciler, pipelineRef, pipelineNS)
+
+			By("sink StatefulSet has 2 replicas")
+			var sinkSTS appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "sink"}, &sinkSTS)).To(Succeed())
+			Expect(*sinkSTS.Spec.Replicas).To(Equal(int32(2)))
+
+			By("ingestor StatefulSet has 2 replicas")
+			var ingSTS appsv1.StatefulSet
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: pipelineNS, Name: "ingestor-0"}, &ingSTS)).To(Succeed())
+			Expect(*ingSTS.Spec.Replicas).To(Equal(int32(2)))
+
+			By("2 ingestor output NATS streams exist (one per sink replica)")
+			hash := generatePipelineHash(pipelineID)
+			streams, listErr := nc.ListPipelineStreams(ctx, hash)
+			Expect(listErr).NotTo(HaveOccurred())
+			Expect(streams).To(ContainElement(fmt.Sprintf("gfm-%s-ingestor-out_0", hash)))
+			Expect(streams).To(ContainElement(fmt.Sprintf("gfm-%s-ingestor-out_1", hash)))
 		})
 	})
 })

--- a/internal/controller/fixtures_test.go
+++ b/internal/controller/fixtures_test.go
@@ -1,0 +1,130 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
+)
+
+const testMinimalPipelineConfig = `{"pipeline_id":"%s","sources":[],"sink":{"type":"clickhouse"}}`
+
+func minimalConfig(id string) string {
+	return fmt.Sprintf(testMinimalPipelineConfig, id)
+}
+
+func simplePipeline(id string, ingestorReplicas, sinkReplicas int32) *etlv1alpha1.Pipeline {
+	return &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineCreateAnnotation: "create",
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID:     id,
+			Config: minimalConfig(id),
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "test-topic-" + id},
+				},
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Ingestor: &etlv1alpha1.IngestorResources{
+					Base: &etlv1alpha1.ComponentResources{Replicas: &ingestorReplicas},
+				},
+				Sink: &etlv1alpha1.ComponentResources{Replicas: &sinkReplicas},
+			},
+		},
+	}
+}
+
+func dedupPipeline(id string) *etlv1alpha1.Pipeline {
+	one := int32(1)
+	dedupWindow := 1 * time.Hour
+	return &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineCreateAnnotation: "create",
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID:     id,
+			Config: minimalConfig(id),
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{
+						TopicName:   "dedup-topic-" + id,
+						DedupWindow: dedupWindow,
+						Deduplication: &etlv1alpha1.Deduplication{
+							Enabled:     true,
+							StorageSize: "1Gi",
+						},
+					},
+				},
+			},
+			Transform: etlv1alpha1.Transform{IsDedupEnabled: true},
+			Sink:      etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Ingestor: &etlv1alpha1.IngestorResources{
+					Base: &etlv1alpha1.ComponentResources{Replicas: &one},
+				},
+				Sink: &etlv1alpha1.ComponentResources{Replicas: &one},
+				Dedup: &etlv1alpha1.ComponentResources{
+					Replicas: &one,
+				},
+			},
+		},
+	}
+}
+
+func joinPipeline(id string, leftReplicas, rightReplicas, joinReplicas, sinkReplicas int32) *etlv1alpha1.Pipeline {
+	return &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      id,
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineCreateAnnotation: "create",
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID:     id,
+			Config: minimalConfig(id),
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "join-left-" + id},
+					{TopicName: "join-right-" + id},
+				},
+			},
+			Join: etlv1alpha1.Join{
+				Type:         "temporal",
+				Enabled:      true,
+				LeftBufferTTL:  5 * time.Minute,
+				RightBufferTTL: 5 * time.Minute,
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+			Resources: &etlv1alpha1.PipelineResources{
+				Ingestor: &etlv1alpha1.IngestorResources{
+					Left:  &etlv1alpha1.ComponentResources{Replicas: &leftReplicas},
+					Right: &etlv1alpha1.ComponentResources{Replicas: &rightReplicas},
+				},
+				Join: &etlv1alpha1.ComponentResources{Replicas: &joinReplicas},
+				Sink: &etlv1alpha1.ComponentResources{Replicas: &sinkReplicas},
+			},
+		},
+	}
+}
+
+func multiReplicaPipeline(id string, replicas int32) *etlv1alpha1.Pipeline {
+	return simplePipeline(id, replicas, replicas)
+}

--- a/internal/controller/fixtures_test.go
+++ b/internal/controller/fixtures_test.go
@@ -107,8 +107,8 @@ func joinPipeline(id string, leftReplicas, rightReplicas, joinReplicas, sinkRepl
 				},
 			},
 			Join: etlv1alpha1.Join{
-				Type:         "temporal",
-				Enabled:      true,
+				Type:           "temporal",
+				Enabled:        true,
 				LeftBufferTTL:  5 * time.Minute,
 				RightBufferTTL: 5 * time.Minute,
 			},

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -87,19 +87,20 @@ func (r *PipelineReconciler) updatePipelineStatus(ctx context.Context, log logr.
 
 	// Update PostgreSQL storage
 	pgStatus := newStatus
-	err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, reason)
-	if err != nil {
-		log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
-		// Don't fail the reconciliation if PostgreSQL update fails, just log the error
-	} else {
-		log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
+	if r.PostgresStorage != nil {
+		err := r.PostgresStorage.UpdatePipelineStatus(ctx, p.Spec.ID, pgStatus, errors, reason)
+		if err != nil {
+			log.Info("failed to update pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus, "error", err)
+			// Don't fail the reconciliation if PostgreSQL update fails, just log the error
+		} else {
+			log.Info("successfully updated pipeline status in PostgreSQL", "pipeline_id", p.Spec.ID, "status", newStatus)
+		}
 	}
 
 	// Update CRD status
 	oldStatus := string(p.Status)
 	p.Status = etlv1alpha1.PipelineStatus(newStatus)
-	err = r.Status().Update(ctx, p, &client.SubResourceUpdateOptions{})
-	if err != nil {
+	if err := r.Status().Update(ctx, p, &client.SubResourceUpdateOptions{}); err != nil {
 		return fmt.Errorf("update pipeline CRD status: %w", err)
 	}
 

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -217,7 +217,11 @@ func (n *NATSClient) CheckConsumerPendingMessages(ctx context.Context, streamNam
 
 	consumer, err := stream.Consumer(infoCtx, consumerName)
 	if err != nil {
-		// Consumer doesn't exist - fail with error as requested
+		var apiErr *jetstream.APIError
+		if errors.As(err, &apiErr) && apiErr.ErrorCode == 10014 {
+			// Consumer not found — treat as no pending messages (safe to proceed with stop)
+			return false, 0, 0, nil
+		}
 		return false, 0, 0, fmt.Errorf("consumer %s does not exist in stream %s: %w", consumerName, streamName, err)
 	}
 

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -363,6 +363,21 @@ func (n *NATSClient) DeleteConsumer(ctx context.Context, streamName, consumerNam
 	return nil
 }
 
+// DeleteAllPipelineStreams deletes all NATS streams belonging to the pipeline (by hash prefix).
+// Best-effort: skips streams that don't exist. Intended for test cleanup.
+func (n *NATSClient) DeleteAllPipelineStreams(ctx context.Context, pipelineHash string) error {
+	names, err := n.ListPipelineStreams(ctx, pipelineHash)
+	if err != nil {
+		return fmt.Errorf("list streams for pipeline %s: %w", pipelineHash, err)
+	}
+	for _, name := range names {
+		if delErr := n.js.DeleteStream(ctx, name); delErr != nil && !errors.Is(delErr, jetstream.ErrStreamNotFound) {
+			return fmt.Errorf("delete stream %s: %w", name, delErr)
+		}
+	}
+	return nil
+}
+
 func (n *NATSClient) Close() error {
 	n.nc.Close()
 	return nil

--- a/test/docker/Dockerfile.noop
+++ b/test/docker/Dockerfile.noop
@@ -1,0 +1,4 @@
+FROM alpine:3.21
+COPY noop.sh /noop.sh
+RUN chmod +x /noop.sh
+ENTRYPOINT ["/noop.sh"]

--- a/test/docker/Dockerfile.noop
+++ b/test/docker/Dockerfile.noop
@@ -1,4 +1,4 @@
 FROM alpine:3.21
-COPY noop.sh /noop.sh
+COPY test/docker/noop.sh /noop.sh
 RUN chmod +x /noop.sh
 ENTRYPOINT ["/noop.sh"]

--- a/test/docker/noop.sh
+++ b/test/docker/noop.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# No-op component for e2e tests. Ignores all args and stays alive so that
+# StatefulSet ReadyReplicas reaches the expected count, allowing the operator
+# create cascade to proceed without real Kafka / ClickHouse connectivity.
+exec sleep infinity

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -36,8 +36,10 @@ var (
 	skipCertManagerInstall = os.Getenv("CERT_MANAGER_INSTALL_SKIP") == "true"
 	// isCertManagerAlreadyInstalled will be set true when CertManager CRDs be found on the cluster
 	isCertManagerAlreadyInstalled = false
-	// isNATSAlreadyInstalled will be set true when a msg be pulished on test JS
+	// isNATSAlreadyInstalled will be set true when a msg be published on test JS
 	isNATSAlreadyInstalled = false
+	// isPostgresAlreadyInstalled will be set true when the postgresql helm release exists
+	isPostgresAlreadyInstalled = false
 
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
@@ -65,15 +67,18 @@ var _ = BeforeSuite(func() {
 	_, err = utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
-	// TODO(user): If you want to change the e2e test vendor from Kind, ensure the image is
-	// built and available before running the tests. Also, remove the following block.
 	By("loading the manager(Operator) image on Kind")
 	err = utils.LoadImageToKindClusterWithName(projectImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
 
-	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
-	// To prevent errors when tests run in environments with CertManager already installed,
-	// we check for their presence before execution.
+	By("building the no-op component image")
+	err = utils.BuildNoopImage()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the no-op component image")
+
+	By("loading the no-op component image on Kind")
+	err = utils.LoadImageToKindClusterWithName(utils.NoopComponentImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the no-op component image into Kind")
+
 	// Setup CertManager before the suite if not skipped and if not already installed
 	if !skipCertManagerInstall {
 		By("checking if cert manager is installed already")
@@ -94,6 +99,19 @@ var _ = BeforeSuite(func() {
 	} else {
 		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: NATS is already installed. Skipping installation...\n")
 	}
+
+	// Postgres is optional — operator now starts without it (delete ops skip postgres).
+	// Install it anyway for completeness; tests don't depend on it directly.
+	By("checking if postgres is installed already")
+	isPostgresAlreadyInstalled = utils.IsPostgresInstalled()
+	if !isPostgresAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Installing PostgreSQL...\n")
+		if err := utils.InstallPostgres(); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: PostgreSQL installation failed: %v — continuing without it\n", err)
+		}
+	} else {
+		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: PostgreSQL is already installed. Skipping installation...\n")
+	}
 })
 
 var _ = AfterSuite(func() {
@@ -103,8 +121,13 @@ var _ = AfterSuite(func() {
 		utils.UninstallCertManager()
 	}
 
-	if !isCertManagerAlreadyInstalled {
+	if !isNATSAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling NATS...\n")
 		utils.UninstallNATS()
+	}
+
+	if !isPostgresAlreadyInstalled {
+		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling PostgreSQL...\n")
+		utils.UninstallPostgres()
 	}
 })

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/test/utils"
 )
 
+// managerNamespace is the namespace where the operator is deployed.
+// Shared between suite setup (BeforeSuite/AfterSuite) and Manager tests.
+const managerNamespace = "glassflow-etl-k8s-operator-system"
+
 var (
 	// Optional Environment Variables:
 	// - CERT_MANAGER_INSTALL_SKIP=true: Skips CertManager installation during test setup.
@@ -112,9 +116,41 @@ var _ = BeforeSuite(func() {
 	} else {
 		_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: PostgreSQL is already installed. Skipping installation...\n")
 	}
+
+	By("creating manager namespace")
+	cmd = exec.Command("kubectl", "create", "ns", managerNamespace)
+	_, _ = utils.Run(cmd) // ignore error if already exists
+
+	By("labeling the namespace to enforce the restricted security policy")
+	cmd = exec.Command("kubectl", "label", "--overwrite", "ns", managerNamespace,
+		"pod-security.kubernetes.io/enforce=restricted")
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+
+	By("installing CRDs")
+	cmd = exec.Command("make", "install")
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to install CRDs")
+
+	By("deploying the controller-manager with e2e overlay (noop component images)")
+	cmd = exec.Command("make", "deploy-e2e", fmt.Sprintf("IMG=%s", projectImage))
+	_, err = utils.Run(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 })
 
 var _ = AfterSuite(func() {
+	By("undeploying the controller-manager")
+	cmd := exec.Command("make", "undeploy")
+	_, _ = utils.Run(cmd)
+
+	By("uninstalling CRDs")
+	cmd = exec.Command("make", "uninstall")
+	_, _ = utils.Run(cmd)
+
+	By("removing manager namespace")
+	cmd = exec.Command("kubectl", "delete", "ns", managerNamespace, "--ignore-not-found")
+	_, _ = utils.Run(cmd)
+
 	// Teardown CertManager after the suite if not skipped and if it was not already installed
 	if !skipCertManagerInstall && !isCertManagerAlreadyInstalled {
 		_, _ = fmt.Fprintf(GinkgoWriter, "Uninstalling CertManager...\n")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -53,8 +54,8 @@ var _ = Describe("Manager", Ordered, func() {
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
 
-		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", projectImage))
+		By("deploying the controller-manager with e2e overlay (noop component images)")
+		cmd = exec.Command("make", "deploy-e2e", fmt.Sprintf("IMG=%s", projectImage))
 		_, err = utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
 	})
@@ -145,11 +146,226 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 			Eventually(verifyControllerUp).Should(Succeed())
 		})
+	})
+})
 
-		// +kubebuilder:scaffold:e2e-webhooks-checks
+// pipelineStatus polls the Pipeline CR and returns its .status field.
+func pipelineStatus(name, ns string) func(g Gomega) string { //nolint:unparam
+	return func(g Gomega) string {
+		cmd := exec.Command("kubectl", "get", "pipeline", name,
+			"-n", ns, "-o", "jsonpath={.status}")
+		out, err := utils.Run(cmd)
+		g.Expect(err).NotTo(HaveOccurred())
+		return out
+	}
+}
 
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by checking the controller logs or resource status.
+// kubectlApplyPipelineCR creates or updates a Pipeline CR from a YAML string.
+func kubectlApplyPipelineCR(yaml string) error {
+	cmd := exec.Command("kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(yaml)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+// kubectlAnnotatePipeline adds an annotation to a Pipeline CR.
+func kubectlAnnotatePipeline(name, ns, annotation string) error { //nolint:unparam
+	cmd := exec.Command("kubectl", "annotate", "--overwrite", "pipeline", name,
+		"-n", ns, annotation)
+	_, err := utils.Run(cmd)
+	return err
+}
+
+// simplePipelineYAML returns a minimal Pipeline CR YAML for e2e tests.
+func simplePipelineYAML(name, pipelineID string) string {
+	return fmt.Sprintf(`apiVersion: etl.glassflow.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: %s
+  namespace: default
+  annotations:
+    pipeline.etl.glassflow.io/create: "create"
+spec:
+  pipeline_id: %s
+  config: '{"pipeline_id":"%s","sources":[],"sink":{"type":"clickhouse"}}'
+  sources:
+    type: kafka
+    topics:
+    - topic_name: e2e-topic-%s
+  join:
+    type: ""
+    enabled: false
+  sink:
+    type: clickhouse
+  pipeline_resources:
+    ingestor:
+      base:
+        replicas: 1
+    sink:
+      replicas: 1
+`, name, pipelineID, pipelineID, pipelineID)
+}
+
+func joinPipelineYAML(name, pipelineID string) string {
+	return fmt.Sprintf(`apiVersion: etl.glassflow.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: %s
+  namespace: default
+  annotations:
+    pipeline.etl.glassflow.io/create: "create"
+spec:
+  pipeline_id: %s
+  config: '{"pipeline_id":"%s","sources":[],"sink":{"type":"clickhouse"}}'
+  sources:
+    type: kafka
+    topics:
+    - topic_name: e2e-left-%s
+    - topic_name: e2e-right-%s
+  join:
+    type: temporal
+    enabled: true
+    left_buffer_ttl: 300000000000
+    right_buffer_ttl: 300000000000
+  sink:
+    type: clickhouse
+  pipeline_resources:
+    ingestor:
+      left:
+        replicas: 1
+      right:
+        replicas: 1
+    join:
+      replicas: 1
+    sink:
+      replicas: 1
+`, name, pipelineID, pipelineID, pipelineID, pipelineID)
+}
+
+var _ = Describe("Pipeline", Ordered, func() {
+	SetDefaultEventuallyTimeout(5 * time.Minute)
+	SetDefaultEventuallyPollingInterval(3 * time.Second)
+
+	Context("Simple kafka pipeline lifecycle", func() {
+		const (
+			pipelineName = "e2e-simple"
+			pipelineID   = "e2e-simple"
+			pipelineNS   = "default"
+			componentNS  = "pipeline-" + pipelineID
+		)
+
+		AfterAll(func() {
+			// Force cleanup regardless of test outcome
+			_ = kubectlAnnotatePipeline(pipelineName, pipelineNS, "pipeline.etl.glassflow.io/delete=delete")
+			time.Sleep(5 * time.Second)
+			cmd := exec.Command("kubectl", "delete", "pipeline", pipelineName, "-n", pipelineNS, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "ns", componentNS, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should create namespace, StatefulSets, and reach Running status", func() {
+			Expect(kubectlApplyPipelineCR(simplePipelineYAML(pipelineName, pipelineID))).To(Succeed())
+
+			By("waiting for pipeline to reach Running status")
+			Eventually(func(g Gomega) {
+				status := pipelineStatus(pipelineName, pipelineNS)(g)
+				g.Expect(status).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying pipeline namespace exists")
+			cmd := exec.Command("kubectl", "get", "ns", componentNS)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying sink StatefulSet exists")
+			cmd = exec.Command("kubectl", "get", "statefulset", "sink", "-n", componentNS)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying ingestor StatefulSet exists")
+			cmd = exec.Command("kubectl", "get", "statefulset", "ingestor-0", "-n", componentNS)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying headless services exist")
+			cmd = exec.Command("kubectl", "get", "svc", "sink", "-n", componentNS)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should stop pipeline", func() {
+			Expect(kubectlAnnotatePipeline(pipelineName, pipelineNS, "pipeline.etl.glassflow.io/stop=stop")).To(Succeed())
+
+			By("waiting for pipeline to reach Stopped status")
+			Eventually(func(g Gomega) {
+				status := pipelineStatus(pipelineName, pipelineNS)(g)
+				g.Expect(status).To(Equal("Stopped"))
+			}).Should(Succeed())
+		})
+
+		It("should resume pipeline", func() {
+			Expect(kubectlAnnotatePipeline(pipelineName, pipelineNS, "pipeline.etl.glassflow.io/resume=resume")).To(Succeed())
+
+			By("waiting for pipeline to leave Stopped status")
+			Eventually(func(g Gomega) {
+				status := pipelineStatus(pipelineName, pipelineNS)(g)
+				g.Expect(status).NotTo(Equal("Stopped"))
+			}).Should(Succeed())
+		})
+
+		It("should delete pipeline and clean up namespace", func() {
+			Expect(kubectlAnnotatePipeline(pipelineName, pipelineNS, "pipeline.etl.glassflow.io/delete=delete")).To(Succeed())
+
+			By("waiting for pipeline namespace to be deleted")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "ns", componentNS)
+				_, err := utils.Run(cmd)
+				g.Expect(err).To(HaveOccurred(), "namespace should be gone")
+			}).Should(Succeed())
+		})
+	})
+
+	Context("Join pipeline", func() {
+		const (
+			pipelineName = "e2e-join"
+			pipelineID   = "e2e-join"
+			pipelineNS   = "default"
+			componentNS  = "pipeline-" + pipelineID
+		)
+
+		AfterAll(func() {
+			_ = kubectlAnnotatePipeline(pipelineName, pipelineNS, "pipeline.etl.glassflow.io/delete=delete")
+			time.Sleep(5 * time.Second)
+			cmd := exec.Command("kubectl", "delete", "pipeline", pipelineName, "-n", pipelineNS, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "ns", componentNS, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should create 2 ingestors, join, sink and reach Running status", func() {
+			Expect(kubectlApplyPipelineCR(joinPipelineYAML(pipelineName, pipelineID))).To(Succeed())
+
+			By("waiting for pipeline to reach Running status")
+			Eventually(func(g Gomega) {
+				status := pipelineStatus(pipelineName, pipelineNS)(g)
+				g.Expect(status).To(Equal("Running"))
+			}).Should(Succeed())
+
+			By("verifying join StatefulSet exists")
+			cmd := exec.Command("kubectl", "get", "statefulset", "join", "-n", componentNS)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying left ingestor StatefulSet exists")
+			cmd = exec.Command("kubectl", "get", "statefulset", "ingestor-0", "-n", componentNS)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying right ingestor StatefulSet exists")
+			cmd = exec.Command("kubectl", "get", "statefulset", "ingestor-1", "-n", componentNS)
+			_, err = utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -146,6 +146,7 @@ spec:
     type: kafka
     topics:
     - topic_name: e2e-topic-%s
+      dedup_window: 0
   join:
     type: ""
     enabled: false
@@ -175,7 +176,9 @@ spec:
     type: kafka
     topics:
     - topic_name: e2e-left-%s
+      dedup_window: 0
     - topic_name: e2e-right-%s
+      dedup_window: 0
   join:
     type: temporal
     enabled: true

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -227,6 +227,13 @@ var _ = Describe("Pipeline", Ordered, func() {
 			By("waiting for pipeline to reach Running status")
 			Eventually(func(g Gomega) {
 				status := pipelineStatus(pipelineName, pipelineNS)(g)
+				if status != "Running" {
+					cmd := exec.Command("kubectl", "logs", "-l", "control-plane=controller-manager",
+						"-n", managerNamespace, "--tail=20")
+					if logs, err := utils.Run(cmd); err == nil {
+						_, _ = fmt.Fprintf(GinkgoWriter, "operator logs:\n%s\n", logs)
+					}
+				}
 				g.Expect(status).To(Equal("Running"))
 			}).Should(Succeed())
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -28,54 +28,8 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/test/utils"
 )
 
-// namespace where the project is deployed in
-const namespace = "glassflow-etl-k8s-operator-system"
-
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
-
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
-	BeforeAll(func() {
-		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
-
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
-
-		By("installing CRDs")
-		cmd = exec.Command("make", "install")
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
-
-		By("deploying the controller-manager with e2e overlay (noop component images)")
-		cmd = exec.Command("make", "deploy-e2e", fmt.Sprintf("IMG=%s", projectImage))
-		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
-	})
-
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
-	AfterAll(func() {
-
-		By("undeploying the controller-manager")
-		cmd := exec.Command("make", "undeploy")
-		_, _ = utils.Run(cmd)
-
-		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
-		_, _ = utils.Run(cmd)
-
-		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
-		_, _ = utils.Run(cmd)
-	})
 
 	// After each test, check for failures and collect logs, events,
 	// and pod descriptions for debugging.
@@ -83,7 +37,7 @@ var _ = Describe("Manager", Ordered, func() {
 		specReport := CurrentSpecReport()
 		if specReport.Failed() {
 			By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", managerNamespace)
 			controllerLogs, err := utils.Run(cmd)
 			if err == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
@@ -92,7 +46,7 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 
 			By("Fetching Kubernetes events")
-			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+			cmd = exec.Command("kubectl", "get", "events", "-n", managerNamespace, "--sort-by=.lastTimestamp")
 			eventsOutput, err := utils.Run(cmd)
 			if err == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
@@ -101,7 +55,7 @@ var _ = Describe("Manager", Ordered, func() {
 			}
 
 			By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
+			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", managerNamespace)
 			podDescription, err := utils.Run(cmd)
 			if err == nil {
 				fmt.Println("Pod description:\n", podDescription)
@@ -125,7 +79,7 @@ var _ = Describe("Manager", Ordered, func() {
 						"{{ if not .metadata.deletionTimestamp }}"+
 						"{{ .metadata.name }}"+
 						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
+					"-n", managerNamespace,
 				)
 
 				podOutput, err := utils.Run(cmd)
@@ -138,7 +92,7 @@ var _ = Describe("Manager", Ordered, func() {
 				// Validate the pod's status
 				cmd = exec.Command("kubectl", "get",
 					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
+					"-n", managerNamespace,
 				)
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -32,6 +32,15 @@ const (
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 
 	natsHelmchartURL = "https://nats-io.github.io/k8s/helm/charts/"
+
+	postgresHelmchartURL  = "https://charts.bitnami.com/bitnami"
+	postgresHelmRelease   = "postgresql"
+	postgresHelmChart     = "bitnami/postgresql"
+	postgresAdminPassword = "testpass"
+
+	// NoopComponentImage is the test image built from test/docker/Dockerfile.noop.
+	// Components use this image so pods start and become Ready without real Kafka/ClickHouse.
+	NoopComponentImage = "glassflow-noop-component:test"
 )
 
 func warnError(err error) {
@@ -194,6 +203,88 @@ func GetProjectDir() (string, error) {
 	}
 	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
+}
+
+// InstallPostgres installs PostgreSQL via Helm (bitnami chart) into the default namespace.
+func InstallPostgres() error {
+	cmd := exec.Command("helm", "repo", "add", "bitnami", postgresHelmchartURL)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("add bitnami repo: %w", err)
+	}
+
+	cmd = exec.Command("helm", "repo", "update")
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("update helm repos: %w", err)
+	}
+
+	cmd = exec.Command(
+		"helm", "install", postgresHelmRelease, postgresHelmChart,
+		"--set", fmt.Sprintf("auth.postgresPassword=%s", postgresAdminPassword),
+		"--set", "primary.persistence.enabled=false",
+		"--wait",
+		"--timeout", "5m",
+	)
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("install postgresql: %w", err)
+	}
+	return nil
+}
+
+// IsPostgresInstalled checks whether the postgresql helm release exists and is healthy.
+func IsPostgresInstalled() bool {
+	cmd := exec.Command("helm", "status", postgresHelmRelease)
+	output, err := Run(cmd)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(output, "deployed")
+}
+
+// UninstallPostgres removes the postgresql helm release.
+func UninstallPostgres() {
+	cmd := exec.Command("helm", "delete", postgresHelmRelease)
+	if _, err := Run(cmd); err != nil {
+		warnError(fmt.Errorf("uninstall postgresql: %w", err))
+	}
+}
+
+// BuildNoopImage builds the no-op component Docker image used in e2e tests.
+func BuildNoopImage() error {
+	dir, _ := GetProjectDir()
+	cmd := exec.Command("docker", "build",
+		"-t", NoopComponentImage,
+		"-f", "test/docker/Dockerfile.noop",
+		".",
+	)
+	cmd.Dir = dir
+	if _, err := Run(cmd); err != nil {
+		return fmt.Errorf("build noop image: %w", err)
+	}
+	return nil
+}
+
+// ListNATSStreams returns stream names from NATS that start with the given prefix,
+// by running nats stream ls inside the nats-box pod.
+func ListNATSStreams(prefix string) ([]string, error) {
+	cmd := exec.Command("kubectl", "exec", "-n", "default", "deploy/nats-box", "--",
+		"nats", "stream", "ls", "--json",
+	)
+	output, err := Run(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("list NATS streams: %w", err)
+	}
+
+	var allStreams []string
+	for _, line := range GetNonEmptyLines(output) {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "\"") || strings.HasPrefix(line, prefix) {
+			name := strings.Trim(line, `",`)
+			if strings.HasPrefix(name, prefix) {
+				allStreams = append(allStreams, name)
+			}
+		}
+	}
+	return allStreams, nil
 }
 
 // UncommentCode searches for target in the file and remove the comment prefix

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -68,19 +68,21 @@ func Run(cmd *exec.Cmd) (string, error) {
 }
 
 func InstallNATS() error {
-	cmd := exec.Command("helm", "repo", "add", "nats", natsHelmchartURL)
+	cmd := exec.Command("helm", "repo", "add", "nats", natsHelmchartURL, "--force-update")
 	_, err := Run(cmd)
 	if err != nil {
 		return fmt.Errorf("add nats repo: %w", err)
 	}
 
 	cmd = exec.Command(
-		"helm", "install", "nats", "nats/nats",
+		"helm", "upgrade", "--install", "nats", "nats/nats",
 		"--set", "config.jetstream.enabled=true",
-		"--set", "config.cluster.enabled=true",
+		"--set", "config.cluster.enabled=false",
 		"--set", "service.enabled=true",
 		"--set", "service.ports.nats.enabled=true",
 		"--set", "service.ports.monitor.enabled=false",
+		"--wait",
+		"--timeout", "3m",
 	)
 	_, err = Run(cmd)
 	if err != nil {
@@ -207,7 +209,7 @@ func GetProjectDir() (string, error) {
 
 // InstallPostgres installs PostgreSQL via Helm (bitnami chart) into the default namespace.
 func InstallPostgres() error {
-	cmd := exec.Command("helm", "repo", "add", "bitnami", postgresHelmchartURL)
+	cmd := exec.Command("helm", "repo", "add", "bitnami", postgresHelmchartURL, "--force-update")
 	if _, err := Run(cmd); err != nil {
 		return fmt.Errorf("add bitnami repo: %w", err)
 	}
@@ -218,7 +220,7 @@ func InstallPostgres() error {
 	}
 
 	cmd = exec.Command(
-		"helm", "install", postgresHelmRelease, postgresHelmChart,
+		"helm", "upgrade", "--install", postgresHelmRelease, postgresHelmChart,
 		"--set", fmt.Sprintf("auth.postgresPassword=%s", postgresAdminPassword),
 		"--set", "primary.persistence.enabled=false",
 		"--wait",


### PR DESCRIPTION
## Summary

- **Integration tests** (envtest + real NATS at localhost:4222): 4 test cases covering simple (1 ingestor + 1 sink), join (2 ingestors + join + sink), dedup, and multi-replica pipelines — verifying StatefulSet/Service/NATS stream creation and pipeline status transitions
- **E2E tests** (Kind cluster): full lifecycle for simple pipeline (create → Running → stop → resume → delete) and join pipeline (2 ingestors + join + sink), using a no-op component image (`sleep infinity`) so pods become Ready without real Kafka/ClickHouse
- **No-op image**: `test/docker/Dockerfile.noop` + `noop.sh` — any container using this image stays alive and passes readiness immediately
- **config/e2e kustomize overlay**: patches operator Deployment with noop component images, `imagePullPolicy: Never`, and NATS addresses for Kind
- **Postgres made optional**: nil-guard all `PostgresStorage` calls so the operator starts and handles pipeline deletion without a DSN configured

## Test plan

- [x] `go test ./internal/controller/... -run TestControllers` — all 4 integration tests pass (requires NATS at localhost:4222)
- [x] `go test ./... -skip 'Test(E2E|Controllers)$'` — all unit tests pass
- [x] `go build ./...` + `go vet ./...` — no errors
- [x] `make test-e2e` against Kind cluster — to be verified in CI or manually