### PR TITLE
fix: switch OTLP source streams to DiscardNew discard policy

### DIFF
--- a/internal/controller/nats_resource_plan.go
+++ b/internal/controller/nats_resource_plan.go
@@ -93,7 +93,7 @@ func (r *PipelineReconciler) buildNATSResourcePlan(p etlv1alpha1.Pipeline) (nats
 		case pipelinegraph.NodeTypeIngestor, pipelinegraph.NodeTypeDedup:
 			nodePlan, err = buildNodePlan(graph, node, limits.withDiscard(jetstream.DiscardNew))
 		case pipelinegraph.NodeTypeOTLPSource:
-			nodePlan, err = buildNodePlan(graph, node, limits.withDiscard(jetstream.DiscardOld))
+			nodePlan, err = buildNodePlan(graph, node, limits.withDiscard(jetstream.DiscardNew))
 		// sink doesn't have output
 		default:
 			continue

--- a/internal/controller/nats_resource_plan_test.go
+++ b/internal/controller/nats_resource_plan_test.go
@@ -201,6 +201,7 @@ func TestBuildNATSResourcePlanOTLPSinkOnly(t *testing.T) {
 		{
 			Name:     fmt.Sprintf("gfm-%s-otlp-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-otlp-out.0", hash)},
+			Discard:  jetstream.DiscardNew,
 		},
 	}
 	if !reflect.DeepEqual(plan.OTLPSourceStreams, wantOTLPStreams) {
@@ -242,6 +243,7 @@ func TestBuildNATSResourcePlanOTLPWithDedup(t *testing.T) {
 		{
 			Name:     fmt.Sprintf("gfm-%s-otlp-out_0", hash),
 			Subjects: []string{fmt.Sprintf("gfm-%s-otlp-out.0", hash)},
+			Discard:  jetstream.DiscardNew,
 		},
 	}
 	if !reflect.DeepEqual(plan.OTLPSourceStreams, wantOTLPStreams) {
@@ -320,8 +322,8 @@ func TestBuildNATSResourcePlanJoinWithLeftDedupKVStores(t *testing.T) {
 	}
 }
 
-// TestBuildNATSResourcePlanDiscardPolicy verifies that pipeline internal streams are created
-// with DiscardNew, while DLQ and OTLP source streams retain DiscardOld.
+// TestBuildNATSResourcePlanDiscardPolicy verifies that pipeline internal streams and OTLP source
+// streams use DiscardNew, while the DLQ retains the DiscardOld default.
 func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 	t.Parallel()
 
@@ -377,7 +379,7 @@ func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 		}
 	})
 
-	t.Run("OTLP source streams have DiscardOld", func(t *testing.T) {
+	t.Run("OTLP source streams have DiscardNew", func(t *testing.T) {
 		t.Parallel()
 		pipeline := etlv1alpha1.Pipeline{
 			Spec: etlv1alpha1.PipelineSpec{
@@ -393,8 +395,8 @@ func TestBuildNATSResourcePlanDiscardPolicy(t *testing.T) {
 			t.Fatalf("buildNATSResourcePlan() error: %v", err)
 		}
 		for _, s := range plan.OTLPSourceStreams {
-			if s.Discard != jetstream.DiscardOld {
-				t.Errorf("OTLP source stream %s: Discard = %v, want DiscardOld", s.Name, s.Discard)
+			if s.Discard != jetstream.DiscardNew {
+				t.Errorf("OTLP source stream %s: Discard = %v, want DiscardNew", s.Name, s.Discard)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary

- Switches `NodeTypeOTLPSource` stream discard policy from `DiscardOld` to `DiscardNew` in `buildNATSResourcePlan`
- NATS now rejects new publishes when the stream is full, propagating back-pressure to the OTLP publisher instead of silently dropping oldest messages
- Updates all test assertions that expected `DiscardOld` on OTLP source streams

Closes ETL-1050