### PR TITLE
Chart metadata for ArtifactHub: logo, home, description (ETL-1089)

### DIFF
--- a/charts/glassflow-operator/Chart.yaml
+++ b/charts/glassflow-operator/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: glassflow-operator
-description: GlassFlow Operator chart
+description: Kubernetes operator for managing GlassFlow ETL pipelines — reconciles Pipeline CRs into per-pipeline data-plane workloads
+home: https://www.glassflow.dev
+icon: https://charts.glassflow.dev/logo.svg
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives
@@ -13,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.


### PR DESCRIPTION
Adds the GlassFlow logo, homepage URL, and a meaningful chart description so the [glassflow-operator chart page on ArtifactHub](https://artifacthub.io/packages/helm/glassflow-operator/glassflow-operator) renders properly. Mirrors ETL-1088 (which fixed the umbrella `glassflow-etl` chart).

## Changes

`charts/glassflow-operator/Chart.yaml`:

- `icon: https://charts.glassflow.dev/logo.svg` — reuses the logomark already hosted on the umbrella charts repo so there's a single source of truth
- `home: https://www.glassflow.dev`
- `description: Kubernetes operator for managing GlassFlow ETL pipelines — reconciles Pipeline CRs into per-pipeline data-plane workloads` (replaces the generic `GlassFlow Operator chart`)
- `version: 0.8.1 → 0.8.2`

## Verification

- `helm lint` clean
- After merge + release, ArtifactHub picks up the new fields on the next scrape of `index.yaml`.

Resolves ETL-1089.