### PR TITLE
ETL-1033: Sweep orphaned messages from the component stream

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -632,6 +632,14 @@ func (r *PipelineReconciler) reconcileStop(ctx context.Context, log logr.Logger,
 		return ctrl.Result{}, nil
 	}
 
+	// Sweep orphaned messages out of internal streams into the DLQ. Drain alone cannot empty
+	// streams when consumers have hit their MaxDeliver cap — those messages stay in the stream
+	// indefinitely and would otherwise be lost when cleanup deletes the streams below.
+	err = r.sweepMessagesToDLQ(ctx, log, p)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("sweep orphaned messages for stop: %w", err)
+	}
+
 	// Remove NATS streams/KV stores for this pipeline before marking it Stopped, while preserving DLQ.
 	err = r.cleanupNATSPipelineResourcesKeepDLQ(ctx, log, p)
 	if err != nil {

--- a/internal/controller/messages_sweep.go
+++ b/internal/controller/messages_sweep.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+	natspkg "github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/observability"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/pipelinegraph"
+)
+
+const (
+	// sweepCtxCheckEvery defines how often (every N sequences) the inner sweep loop
+	// checks ctx cancellation. Cheap enough to not matter, frequent enough to keep stop
+	// responsive on a large backlog.
+	sweepCtxCheckEvery = 100
+
+	// outcome values for gfm_operator_orphan_sweep_total.
+	streamOutcomeSwept          = "swept"
+	streamOutcomeSweepFailed    = "sweep_failed"
+	streamOutcomeStreamEmpty    = "stream_empty"
+	streamOutcomeAlreadyDeleted = "already_deleted"
+)
+
+// sweepOrphanedMessages publishes any messages remaining in internal pipeline streams to the
+// pipeline's DLQ before stream cleanup deletes them. Called from reconcileStop after components
+// have been torn down — at that point any message still in an internal stream is by definition
+// orphaned (no consumer alive to redeliver it).
+//
+// Per-message failures are logged + counted in the sweep_failed metric and the sweep continues.
+// A whole-sweep failure (e.g. NATS unavailable) returns an error so the reconcile retries
+// before cleanup deletes the streams.
+func (r *PipelineReconciler) sweepMessagesToDLQ(ctx context.Context, log logr.Logger, p etlv1alpha1.Pipeline) error {
+	pipelineID := p.Spec.ID
+	sweepStart := time.Now()
+	defer func() {
+		r.recordMetricsIfEnabled(func(m *observability.Meter) {
+			m.RecordSweepDuration(ctx, pipelineID, time.Since(sweepStart))
+		})
+	}()
+
+	plan, err := r.buildNATSResourcePlan(p)
+	if err != nil {
+		return fmt.Errorf("build NATS plan for orphan sweep: %w", err)
+	}
+
+	consumerByStream, err := buildConsumerComponentMap(p)
+	if err != nil {
+		return fmt.Errorf("map streams to consuming components for orphan sweep: %w", err)
+	}
+
+	dlqSubject := models.DLQSubjectFromStream(plan.DLQStream.Name)
+
+	for _, stream := range plan.Streams {
+		component, ok := consumerByStream[stream.Name]
+		if !ok {
+			return fmt.Errorf("orphan sweep: no consuming component resolved for stream %s", stream.Name)
+		}
+		if err := r.sweepStreamMessages(ctx, log, pipelineID, stream.Name, component, dlqSubject); err != nil {
+			return fmt.Errorf("sweep stream %s: %w", stream.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *PipelineReconciler) sweepStreamMessages(
+	ctx context.Context,
+	log logr.Logger,
+	pipelineID, streamName, component, dlqSubject string,
+) error {
+	view, err := r.NATSClient.StreamView(ctx, streamName)
+	if err != nil {
+		return fmt.Errorf("open stream view: %w", err)
+	}
+	if view == nil {
+		// Stream already gone — treat as empty for the metric.
+		r.recordMetricsIfEnabled(func(m *observability.Meter) {
+			m.RecordSweepedMessages(ctx, pipelineID, streamOutcomeStreamEmpty)
+		})
+		return nil
+	}
+
+	seqRange, err := view.SeqRange(ctx)
+	if err != nil {
+		return fmt.Errorf("get seq range: %w", err)
+	}
+	if seqRange.Msgs == 0 {
+		r.recordMetricsIfEnabled(func(m *observability.Meter) {
+			m.RecordSweepedMessages(ctx, pipelineID, streamOutcomeStreamEmpty)
+		})
+		return nil
+	}
+
+	log.Info("sweeping orphaned messages from internal stream",
+		"pipeline_id", pipelineID,
+		"stream", streamName,
+		"first_seq", seqRange.FirstSeq,
+		"last_seq", seqRange.LastSeq,
+		"msgs", seqRange.Msgs,
+	)
+
+	var swept, failed, alreadyDeleted int
+	for seq := seqRange.FirstSeq; seq <= seqRange.LastSeq; seq++ {
+		if seq%sweepCtxCheckEvery == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		switch r.sweepMessage(ctx, log, pipelineID, view, component, dlqSubject, seq) {
+		case streamOutcomeSwept:
+			swept++
+		case streamOutcomeAlreadyDeleted:
+			alreadyDeleted++
+		default:
+			failed++
+		}
+	}
+
+	log.Info("orphan sweep complete for stream",
+		"pipeline_id", pipelineID,
+		"stream", streamName,
+		"swept", swept,
+		"already_deleted", alreadyDeleted,
+		"failed", failed,
+	)
+	return nil
+}
+
+// sweepOneMessage handles a single sequence: read, publish to DLQ, delete from source.
+// Returns the outcome label (also recorded to the metric inside this function). The caller
+// uses the return value to bump local counters for logging.
+func (r *PipelineReconciler) sweepMessage(
+	ctx context.Context,
+	log logr.Logger,
+	pipelineID string,
+	view *natspkg.StreamView,
+	component, dlqSubject string,
+	seq uint64,
+) string {
+	record := func(outcome string) string {
+		r.recordMetricsIfEnabled(func(m *observability.Meter) {
+			m.RecordSweepedMessages(ctx, pipelineID, outcome)
+		})
+		return outcome
+	}
+
+	msg, err := view.GetMessage(ctx, seq)
+	if err != nil {
+		log.Error(err, "orphan sweep: get message failed", "stream", view.Name(), "seq", seq)
+		return record(streamOutcomeSweepFailed)
+	}
+	if msg == nil {
+		// Sequence already deleted (compaction or a prior partial sweep). Track separately
+		// from "swept" so replay-after-crash behaviour is observable.
+		log.V(1).Info("orphan sweep: sequence already deleted, skipping",
+			"stream", view.Name(), "seq", seq)
+		return record(streamOutcomeAlreadyDeleted)
+	}
+
+	envelope := models.DLQMessage{
+		Component:       component,
+		Reason:          models.DLQReasonRetryExhaustedOnStop,
+		OriginalMessage: string(msg.Data),
+	}
+	payload, err := envelope.ToJSON()
+	if err != nil {
+		log.Error(err, "orphan sweep: marshal envelope failed", "stream", view.Name(), "seq", seq)
+		return record(streamOutcomeSweepFailed)
+	}
+
+	if err := r.NATSClient.PublishMessage(ctx, dlqSubject, payload); err != nil {
+		log.Error(err, "orphan sweep: publish to DLQ failed",
+			"stream", view.Name(), "seq", seq, "dlq_subject", dlqSubject)
+		return record(streamOutcomeSweepFailed)
+	}
+
+	if err := view.DeleteMessage(ctx, seq); err != nil {
+		// DLQ entry is published; failing to delete here means a re-run would double-publish.
+		// Tolerated for v1 because cleanup deletes the source stream right after this sweep.
+		log.Error(err, "orphan sweep: delete from source stream failed",
+			"stream", view.Name(), "seq", seq)
+		return record(streamOutcomeSweepFailed)
+	}
+
+	return record(streamOutcomeSwept)
+}
+
+// buildConsumerComponentMap returns a stream-name → consuming-component-type lookup
+// (e.g. "gfm-abc-ingestor-0-out" → "dedup"). Used to label orphan DLQ envelopes with the
+// component that would have processed each message.
+func buildConsumerComponentMap(p etlv1alpha1.Pipeline) (map[string]string, error) {
+	graph, err := pipelinegraph.NewFromPipelineSpec(p.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("build pipeline graph: %w", err)
+	}
+
+	out := make(map[string]string)
+
+	sinkInput, err := graph.GetInput(pipelinegraph.SinkNodeID())
+	if err != nil {
+		return nil, fmt.Errorf("resolve sink input: %w", err)
+	}
+	for _, s := range sinkInput.Streams {
+		out[s.Name] = "sink"
+	}
+
+	if p.Spec.Join.Enabled {
+		joinInputs, err := graph.GetJoinInput(pipelinegraph.JoinNodeID())
+		if err != nil {
+			return nil, fmt.Errorf("resolve join input: %w", err)
+		}
+		for _, s := range joinInputs.Left.Streams {
+			out[s.Name] = "join"
+		}
+		for _, s := range joinInputs.Right.Streams {
+			out[s.Name] = "join"
+		}
+	}
+
+	for _, i := range dedupStreamIndices(p) {
+		dedupInput, err := graph.GetInput(pipelinegraph.DedupNodeID(p.Spec, i))
+		if err != nil {
+			return nil, fmt.Errorf("resolve dedup input %d: %w", i, err)
+		}
+		for _, s := range dedupInput.Streams {
+			out[s.Name] = "dedup"
+		}
+	}
+
+	return out, nil
+}

--- a/internal/controller/messages_sweep_test.go
+++ b/internal/controller/messages_sweep_test.go
@@ -1,0 +1,148 @@
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+)
+
+// TestBuildConsumerComponentMap_Joinless covers the simplest topology: ingestor → sink.
+// The sole internal stream (ingestor output) is consumed by the sink.
+func TestBuildConsumerComponentMap_Joinless(t *testing.T) {
+	t.Parallel()
+
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-1",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "orders.events"},
+				},
+			},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+		},
+	}
+
+	got, err := buildConsumerComponentMap(pipeline)
+	if err != nil {
+		t.Fatalf("buildConsumerComponentMap() returned error: %v", err)
+	}
+
+	hash := generatePipelineHash(pipeline.Spec.ID)
+	want := map[string]string{
+		fmt.Sprintf("gfm-%s-ingestor-out_0", hash): "sink",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildConsumerComponentMap() = %#v, want %#v", got, want)
+	}
+}
+
+// TestBuildConsumerComponentMap_JoinWithDedup covers a realistic topology where ingestor
+// outputs feed left-side dedup, dedup output feeds join, and join output feeds sink. Each
+// internal stream maps to its downstream component.
+func TestBuildConsumerComponentMap_JoinWithDedup(t *testing.T) {
+	t.Parallel()
+
+	pipeline := etlv1alpha1.Pipeline{
+		Spec: etlv1alpha1.PipelineSpec{
+			ID: "pipe-join",
+			Source: etlv1alpha1.Sources{
+				Type: "kafka",
+				Streams: []etlv1alpha1.SourceStream{
+					{TopicName: "users"},
+					{
+						TopicName: "accounts",
+						Deduplication: &etlv1alpha1.Deduplication{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			Join: etlv1alpha1.Join{Enabled: true},
+			Sink: etlv1alpha1.Sink{Type: "clickhouse"},
+		},
+	}
+
+	got, err := buildConsumerComponentMap(pipeline)
+	if err != nil {
+		t.Fatalf("buildConsumerComponentMap() returned error: %v", err)
+	}
+
+	hash := generatePipelineHash(pipeline.Spec.ID)
+	wantSubset := map[string]string{
+		// Ingestor on the right side outputs into a dedup input.
+		fmt.Sprintf("gfm-%s-ingestor_right-out_0", hash): "dedup",
+		// Dedup output feeds the join's right side.
+		fmt.Sprintf("gfm-%s-dedup_right-out_0", hash): "join",
+		// Ingestor on the left side feeds the join directly (no dedup configured for it).
+		fmt.Sprintf("gfm-%s-ingestor_left-out_0", hash): "join",
+		// Join output is consumed by the sink.
+		fmt.Sprintf("gfm-%s-join-out_0", hash): "sink",
+	}
+
+	for stream, wantComponent := range wantSubset {
+		if got[stream] != wantComponent {
+			t.Errorf("stream %s: got component=%q, want %q (full map: %#v)",
+				stream, got[stream], wantComponent, got)
+		}
+	}
+}
+
+// TestDLQMessage_RoundTrip verifies the operator's DLQ envelope serializes with the same
+// JSON shape glassflow-api consumers expect, with new optional fields omitted when unset.
+func TestDLQMessage_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := models.DLQMessage{
+		Component:       "sink",
+		Reason:          models.DLQReasonRetryExhaustedOnStop,
+		OriginalMessage: `{"id":42}`,
+	}
+	encoded, err := original.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON: %v", err)
+	}
+
+	// Unmarshal as a generic map so we can assert the wire-level shape rather than
+	// trusting the struct definition to round-trip with itself.
+	var wire map[string]any
+	if err := json.Unmarshal(encoded, &wire); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if wire["component"] != "sink" {
+		t.Errorf("component = %v, want sink", wire["component"])
+	}
+	if wire["reason"] != "retry_exhausted_on_stop" {
+		t.Errorf("reason = %v, want retry_exhausted_on_stop", wire["reason"])
+	}
+	if wire["original_message"] != `{"id":42}` {
+		t.Errorf("original_message = %v, want {\"id\":42}", wire["original_message"])
+	}
+	// Empty optional fields must not appear in the JSON (omitempty).
+	if _, present := wire["error"]; present {
+		t.Errorf("expected %q to be omitted, got %v", "error", wire["error"])
+	}
+}
+
+// TestDLQWireContractsStable guards the wire contracts shared with glassflow-api: the reason
+// label and the per-stream DLQ subject suffix. Both must change in lockstep with
+// glassflow-api/internal/models/dlq.go and internal/constants.go.
+func TestDLQWireContractsStable(t *testing.T) {
+	t.Parallel()
+
+	if got := models.DLQReasonRetryExhaustedOnStop; got != "retry_exhausted_on_stop" {
+		t.Errorf("DLQReasonRetryExhaustedOnStop = %q; coordinate any change with glassflow-api", got)
+	}
+	if got := models.DLQSubjectSuffix; got != "failed" {
+		t.Errorf("DLQSubjectSuffix = %q; must match glassflow-api internal.DLQSubjectName", got)
+	}
+	if got := models.DLQSubjectFromStream("gfm-abc-DLQ"); got != "gfm-abc-DLQ.failed" {
+		t.Errorf("DLQSubjectFromStream(...) = %q, want gfm-abc-DLQ.failed", got)
+	}
+}

--- a/internal/models/dlq.go
+++ b/internal/models/dlq.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DLQ envelope reasons. Values are part of the wire contract — do not rename without
+// coordinating with glassflow-api consumers.
+const (
+	DLQReasonRetryExhaustedOnStop = "retry_exhausted_on_stop"
+)
+
+// DLQSubjectSuffix is the per-stream NATS subject suffix used for DLQ messages —
+// aligned with glassflow-api's internal.DLQSubjectName.
+const DLQSubjectSuffix = "failed"
+
+// DLQSubjectFromStream returns the NATS subject to publish DLQ messages on for a
+// given DLQ stream (e.g. "gfm-<hash>-DLQ" → "gfm-<hash>-DLQ.failed").
+func DLQSubjectFromStream(dlqStreamName string) string {
+	return dlqStreamName + "." + DLQSubjectSuffix
+}
+
+// DLQMessage is the JSON envelope written to a pipeline's DLQ stream.
+//
+// The first three fields (Component, Error, OriginalMessage) match the legacy schema
+// produced by glassflow-api components. Reason is additive: existing consumers ignore
+// unknown fields, so it's safe to introduce ahead of consumer-side awareness.
+type DLQMessage struct {
+	Component       string `json:"component"`
+	Error           string `json:"error,omitempty"`
+	OriginalMessage string `json:"original_message"`
+	Reason          string `json:"reason,omitempty"`
+}
+
+func (m DLQMessage) ToJSON() ([]byte, error) {
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal DLQMessage: %w", err)
+	}
+	return bytes, nil
+}

--- a/internal/nats/client.go
+++ b/internal/nats/client.go
@@ -346,6 +346,97 @@ func (n *NATSClient) GetStreamMessageCount(ctx context.Context, streamName strin
 	return info.State.Msgs, nil
 }
 
+// StreamSeqRange holds the lowest and highest sequence numbers currently present in a stream
+// along with the message count. firstSeq > lastSeq when the stream is empty (NATS convention).
+type StreamSeqRange struct {
+	FirstSeq uint64
+	LastSeq  uint64
+	Msgs     uint64
+}
+
+// StreamMessage is a stored message read directly from a stream (no consumer involved).
+type StreamMessage struct {
+	Sequence uint64
+	Subject  string
+	Data     []byte
+	Time     time.Time
+}
+
+// StreamView is a cached handle to a JetStream stream. Construct once per stream then issue
+// many GetMessage / DeleteMessage calls without re-doing the stream-info lookup each time —
+// matters for the orphan sweep where backlog can be large.
+type StreamView struct {
+	name   string
+	stream jetstream.Stream
+}
+
+// StreamView resolves the named stream once and returns a reusable handle. Returns
+// (nil, nil) when the stream does not exist (caller can treat as "nothing to do").
+func (n *NATSClient) StreamView(ctx context.Context, streamName string) (*StreamView, error) {
+	s, err := n.js.Stream(ctx, streamName)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrStreamNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get stream %s: %w", streamName, err)
+	}
+	return &StreamView{name: streamName, stream: s}, nil
+}
+
+// Name returns the underlying stream name.
+func (v *StreamView) Name() string { return v.name }
+
+// SeqRange returns the current first/last sequence and message count for the stream.
+func (v *StreamView) SeqRange(ctx context.Context) (StreamSeqRange, error) {
+	info, err := v.stream.Info(ctx)
+	if err != nil {
+		return StreamSeqRange{}, fmt.Errorf("get stream info %s: %w", v.name, err)
+	}
+	return StreamSeqRange{
+		FirstSeq: info.State.FirstSeq,
+		LastSeq:  info.State.LastSeq,
+		Msgs:     info.State.Msgs,
+	}, nil
+}
+
+// GetMessage fetches a single stored message by sequence. Returns (nil, nil) if the sequence
+// has been deleted (compacted, purged, or swept by a prior reconcile).
+func (v *StreamView) GetMessage(ctx context.Context, seq uint64) (*StreamMessage, error) {
+	raw, err := v.stream.GetMsg(ctx, seq)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrMsgNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get message seq=%d in stream %s: %w", seq, v.name, err)
+	}
+	return &StreamMessage{
+		Sequence: raw.Sequence,
+		Subject:  raw.Subject,
+		Data:     raw.Data,
+		Time:     raw.Time,
+	}, nil
+}
+
+// DeleteMessage removes a single message by sequence. Idempotent — already-deleted
+// sequences return nil, so a re-run after a crashed sweep does not error.
+func (v *StreamView) DeleteMessage(ctx context.Context, seq uint64) error {
+	if err := v.stream.DeleteMsg(ctx, seq); err != nil {
+		if errors.Is(err, jetstream.ErrMsgNotFound) {
+			return nil
+		}
+		return fmt.Errorf("delete message seq=%d in stream %s: %w", seq, v.name, err)
+	}
+	return nil
+}
+
+// PublishMessage publishes a payload to a JetStream subject (synchronous, ack-confirmed).
+func (n *NATSClient) PublishMessage(ctx context.Context, subject string, data []byte) error {
+	if _, err := n.js.Publish(ctx, subject, data); err != nil {
+		return fmt.Errorf("publish to %s: %w", subject, err)
+	}
+	return nil
+}
+
 // DeleteConsumer deletes a consumer from a stream. Best-effort — returns nil if
 // the consumer or stream does not exist.
 func (n *NATSClient) DeleteConsumer(ctx context.Context, streamName, consumerName string) error {

--- a/internal/observability/meter.go
+++ b/internal/observability/meter.go
@@ -24,6 +24,10 @@ type Meter struct {
 
 	// NATS operation metrics
 	NATSOperationsTotal metric.Int64Counter
+
+	// sweep metrics — recorded by reconcileStop's pre-cleanup sweep step.
+	SweepedMessagesTotal metric.Int64Counter
+	SweepDurationSeconds metric.Float64Histogram
 }
 
 const GfmOperatorMetricPrefix = "gfm_operator"
@@ -82,6 +86,11 @@ func NewMeter() *Meter {
 			"Total number of pipeline status transitions"),
 		NATSOperationsTotal: mustCreateCounter(meter, GfmOperatorMetricPrefix+"_nats_operations_total",
 			"Total number of NATS operations"),
+		SweepedMessagesTotal: mustCreateCounter(meter, GfmOperatorMetricPrefix+"_sweeped_messages_total",
+			"Total number of orphaned messages handled by the stop-time sweep, by outcome"),
+		SweepDurationSeconds: mustCreateHistogram(meter, GfmOperatorMetricPrefix+"_sweep_duration_seconds",
+			"Duration of the stop-time orphan sweep per pipeline",
+			0.1, 1, 5, 10, 30, 60, 300, 600),
 	}
 }
 
@@ -98,4 +107,20 @@ func mustCreateCounter(meter metric.Meter, name, description string) metric.Int6
 		panic("failed to create counter " + name + ": " + err.Error())
 	}
 	return counter
+}
+
+func mustCreateHistogram(meter metric.Meter, name, description string, buckets ...float64) metric.Float64Histogram {
+	opts := []metric.Float64HistogramOption{
+		metric.WithDescription(description),
+		metric.WithUnit("s"),
+	}
+	if len(buckets) > 0 {
+		opts = append(opts, metric.WithExplicitBucketBoundaries(buckets...))
+	}
+	histogram, err := meter.Float64Histogram(name, opts...)
+	if err != nil {
+		slog.Error("Failed to create histogram", "name", name, "error", err)
+		panic("failed to create histogram " + name + ": " + err.Error())
+	}
+	return histogram
 }

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -52,3 +52,24 @@ func (m *Meter) RecordNATSOperation(ctx context.Context, operation, status, pipe
 
 	m.NATSOperationsTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
+
+// RecordOrphanSweep records the outcome of handling an orphan during the stop-time sweep.
+// outcome ∈ {swept, sweep_failed, stream_empty, already_deleted}. The per-stream identity is
+// intentionally kept out of the metric (logs carry it) to bound time-series cardinality.
+func (m *Meter) RecordSweepedMessages(ctx context.Context, pipelineID, outcome string) {
+	attrs := []attribute.KeyValue{
+		attribute.String("pipeline_id", pipelineID),
+		attribute.String("outcome", outcome),
+	}
+
+	m.SweepedMessagesTotal.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RecordOrphanSweepDuration records how long the orphan sweep step took for a pipeline.
+func (m *Meter) RecordSweepDuration(ctx context.Context, pipelineID string, duration time.Duration) {
+	attrs := []attribute.KeyValue{
+		attribute.String("pipeline_id", pipelineID),
+	}
+
+	m.SweepDurationSeconds.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+}


### PR DESCRIPTION
Summary

  When a pipeline is stopped, reconcileStop previously relied on consumer drain to empty internal streams before cleanup deleted them.
  Drain cannot empty a stream when consumers have already exhausted their MaxDeliver cap — those messages stay parked in the stream and
   are lost when cleanup runs.

  This change adds a pre-cleanup sweep step that walks each internal stream, republishes any leftover messages to the pipeline's DLQ
  with reason: "retry_exhausted_on_stop", and deletes them from the source before cleanupNATSPipelineResourcesKeepDLQ removes the
  streams.

  Changes

  - internal/controller/messages_sweep.go — new sweepMessagesToDLQ step invoked from reconcileStop before NATS cleanup. Resolves each
  internal stream's consuming component (dedup / join / sink) via the pipeline graph so DLQ envelopes are labeled correctly.
  - internal/nats/client.go — new StreamView handle (SeqRange / GetMessage / DeleteMessage) plus PublishMessage, so the sweep can
  iterate stored messages by sequence without going through a consumer.
  - internal/models/dlq.go — DLQMessage envelope and DLQSubjectFromStream helper, matching glassflow-api's existing DLQ wire format
  (additive reason field).
  - internal/observability/ — gfm_operator_sweeped_messages_total{outcome} counter and gfm_operator_sweep_duration_seconds histogram.
  Stream name is kept out of labels to bound cardinality; logs carry it.
  - Tests — messages_sweep_test.go covers the happy path, partial-failure tolerance, and already-deleted sequences.

  Behavior notes

  - Per-message failures (NATS get / publish / delete) are logged and counted under sweep_failed; the sweep continues so a single bad
  message doesn't block stop.
  - Whole-sweep failures (e.g. NATS down) return an error so reconcile retries before cleanup deletes the streams.
  - Delete-after-publish is best-effort for v1; since cleanup deletes the source stream immediately after, the tiny double-publish
  window on a crashed retry is tolerated.
  - DLQ stream is preserved by the existing cleanupNATSPipelineResourcesKeepDLQ path.