### PR TITLE
ETL-1107: Sweep stuck messages to DLQ on stop timeout

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -352,6 +352,11 @@ func main() {
 		"RECONCILE_TIMEOUT", constants.DefaultReconcileTimeout.String()),
 		"Maximum duration a reconcile operation can run before timing out (e.g. 15m, 1h)")
 
+	var stopReconcileTimeout string
+	flag.StringVar(&stopReconcileTimeout, "stop-reconcile-timeout", getEnvOrDefault(
+		"STOP_RECONCILE_TIMEOUT", constants.DefaultStopReconcileTimeout.String()),
+		"Maximum duration a stop reconcile can run before timing out (e.g. 5m, 10m)")
+
 	opts := zap.Options{
 		Development: true,
 	}
@@ -365,6 +370,14 @@ func main() {
 		parsedReconcileTimeout = constants.DefaultReconcileTimeout
 	}
 	constants.ReconcileTimeout = parsedReconcileTimeout
+
+	parsedStopReconcileTimeout, err := time.ParseDuration(stopReconcileTimeout)
+	if err != nil {
+		setupLog.Error(err, "unable to parse stop reconcile timeout, using default",
+			"value", stopReconcileTimeout, "default", constants.DefaultStopReconcileTimeout.String())
+		parsedStopReconcileTimeout = constants.DefaultStopReconcileTimeout
+	}
+	constants.StopReconcileTimeout = parsedStopReconcileTimeout
 
 	// Get pod identity - use POD_NAME env var if set, otherwise fallback to hostname
 	podName := os.Getenv("POD_NAME")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -40,12 +40,22 @@ const (
 	// DefaultReconcileTimeout is the default maximum duration a reconcile operation can run before timing out
 	DefaultReconcileTimeout = 15 * time.Minute
 
+	// DefaultStopReconcileTimeout is the default maximum duration a stop reconcile can run before
+	// timing out. Stop is intent-clear ("get this off") and benefits from a shorter ceiling than
+	// create/edit, which legitimately need minutes for StatefulSet rollouts.
+	DefaultStopReconcileTimeout = 5 * time.Minute
+
 	DefaultMinReplicas = 1
 )
 
 var (
-	// ReconcileTimeout is the maximum duration a reconcile operation can run before timing out
+	// ReconcileTimeout is the maximum duration a non-stop reconcile operation can run before timing out
 	ReconcileTimeout = DefaultReconcileTimeout
+
+	// StopReconcileTimeout is the maximum duration a stop reconcile can run before timing out.
+	// tryExtendStopTimeout still grants one extension when pending messages are decreasing, so the
+	// effective worst-case wait for a truly stuck pipeline is roughly 2× this value.
+	StopReconcileTimeout = DefaultStopReconcileTimeout
 )
 
 // Pipeline operation type constants

--- a/internal/controller/messages_sweep.go
+++ b/internal/controller/messages_sweep.go
@@ -30,7 +30,7 @@ const (
 	// responsive on a large backlog.
 	sweepCtxCheckEvery = 100
 
-	// outcome values for gfm_operator_orphan_sweep_total.
+	// outcome values for gfm_operator_sweeped_messages_total.
 	streamOutcomeSwept          = "swept"
 	streamOutcomeSweepFailed    = "sweep_failed"
 	streamOutcomeStreamEmpty    = "stream_empty"

--- a/internal/controller/timeout.go
+++ b/internal/controller/timeout.go
@@ -83,6 +83,16 @@ func clearOperationAnnotation(annotations map[string]string, operation string) {
 	}
 }
 
+// operationTimeoutFor returns the active timeout for the given operation. Stop uses a
+// shorter ceiling than the other operations because "stop" is intent-clear and shouldn't
+// wait as long as create/edit, which need minutes for StatefulSet rollouts.
+func operationTimeoutFor(annotations map[string]string) time.Duration {
+	if getPipelineOperationFromAnnotations(annotations) == constants.OperationStop {
+		return constants.StopReconcileTimeout
+	}
+	return constants.ReconcileTimeout
+}
+
 // checkOperationTimeout checks if an operation has exceeded the timeout duration
 // Returns true if timed out, false otherwise, and the elapsed duration
 func (r *PipelineReconciler) checkOperationTimeout(log logr.Logger, p *etlv1alpha1.Pipeline) (bool, time.Duration) {
@@ -104,9 +114,10 @@ func (r *PipelineReconciler) checkOperationTimeout(log logr.Logger, p *etlv1alph
 		return false, 0
 	}
 
+	timeout := operationTimeoutFor(annotations)
 	elapsed := time.Since(startTime)
-	if elapsed > constants.ReconcileTimeout {
-		log.Info("operation timed out", "pipeline_id", p.Spec.ID, "elapsed", elapsed, "timeout", constants.ReconcileTimeout)
+	if elapsed > timeout {
+		log.Info("operation timed out", "pipeline_id", p.Spec.ID, "elapsed", elapsed, "timeout", timeout)
 		return true, elapsed
 	}
 
@@ -140,7 +151,11 @@ func (r *PipelineReconciler) clearOperationStartTime(p *etlv1alpha1.Pipeline) {
 	}
 }
 
-// handleOperationTimeout handles a timed-out operation by updating status to Failed and clearing annotations
+// handleOperationTimeout handles a timed-out operation. Non-stop operations terminate
+// components and end in Failed. Stop is special: after force-terminating components we
+// also sweep orphaned messages to the DLQ and clean up internal NATS streams, then end
+// in Stopped — so a user's stop intent is honoured even when consumers couldn't drain.
+// Sweep or cleanup failures keep the pipeline in Failed so the incident remains visible.
 func (r *PipelineReconciler) handleOperationTimeout(ctx context.Context, log logr.Logger, p *etlv1alpha1.Pipeline) (ctrl.Result, error) {
 	pipelineID := p.Spec.ID
 	operation := getPipelineOperationFromAnnotations(p.GetAnnotations())
@@ -149,14 +164,17 @@ func (r *PipelineReconciler) handleOperationTimeout(ctx context.Context, log log
 		operation = "unknown"
 	}
 
-	log.Error(fmt.Errorf("operation timed out after %v", constants.ReconcileTimeout), "operation timed out", "pipeline_id", pipelineID, "operation", operation)
+	timeout := operationTimeoutFor(p.GetAnnotations())
+	log.Error(fmt.Errorf("operation timed out after %v", timeout), "operation timed out", "pipeline_id", pipelineID, "operation", operation)
 
-	// Update status to Failed with error message
-	errorMsg := fmt.Sprintf("operation timed out after %v", constants.ReconcileTimeout)
-	err := r.updatePipelineStatus(ctx, log, p, models.PipelineStatusFailed, []string{errorMsg}, "timeout")
-	if err != nil {
-		log.Error(err, "failed to update pipeline status to Failed", "pipeline_id", pipelineID)
-		// Continue anyway to clear annotations
+	errorMsg := fmt.Sprintf("operation timed out after %v", timeout)
+	// For stop we defer the terminal status until we know whether the forced sweep + cleanup
+	// succeed, to avoid briefly publishing Failed before flipping back to Stopped.
+	if operation != constants.OperationStop {
+		if err := r.updatePipelineStatus(ctx, log, p, models.PipelineStatusFailed, []string{errorMsg}, "timeout"); err != nil {
+			log.Error(err, "failed to update pipeline status to Failed", "pipeline_id", pipelineID)
+			// Continue anyway to clear annotations
+		}
 	}
 
 	// Clear operation start time
@@ -174,10 +192,34 @@ func (r *PipelineReconciler) handleOperationTimeout(ctx context.Context, log log
 			return result, err
 		}
 
-		p.Status = etlv1alpha1.PipelineStatus(models.PipelineStatusFailed)
-		err = r.Update(ctx, p)
-		if err != nil {
+		finalStatus := models.PipelineStatusFailed
+		var stopErrors []string
+		if operation == constants.OperationStop {
+			if sweepErr := r.sweepMessagesToDLQ(ctx, log, *p); sweepErr != nil {
+				log.Error(sweepErr, "forced stop: sweep orphaned messages failed", "pipeline_id", pipelineID)
+				stopErrors = []string{fmt.Sprintf("forced stop sweep failed: %v", sweepErr)}
+			} else if cleanupErr := r.cleanupNATSPipelineResourcesKeepDLQ(ctx, log, *p); cleanupErr != nil {
+				log.Error(cleanupErr, "forced stop: cleanup NATS resources failed", "pipeline_id", pipelineID)
+				stopErrors = []string{fmt.Sprintf("forced stop cleanup failed: %v", cleanupErr)}
+			} else {
+				finalStatus = models.PipelineStatusStopped
+				r.clearStopLastPendingCount(p)
+			}
+		}
+
+		// Persist annotation clears (and the in-memory status flip) before pushing the
+		// terminal status through updatePipelineStatus. updatePipelineStatus uses the
+		// Status subresource, which intentionally does not carry metadata changes —
+		// so the metadata Update must land first to avoid losing the annotation clears.
+		p.Status = etlv1alpha1.PipelineStatus(finalStatus)
+		if err := r.Update(ctx, p); err != nil {
 			log.Error(err, "failed to clear operation annotation after timeout", "pipeline_id", pipelineID)
+		}
+
+		if operation == constants.OperationStop {
+			if err := r.updatePipelineStatus(ctx, log, p, finalStatus, stopErrors, "timeout"); err != nil {
+				log.Error(err, "failed to update pipeline final status after forced stop", "pipeline_id", pipelineID)
+			}
 		}
 	}
 

--- a/internal/controller/timeout_stop_test.go
+++ b/internal/controller/timeout_stop_test.go
@@ -1,0 +1,223 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	etlv1alpha1 "github.com/glassflow/glassflow-etl-k8s-operator/api/v1alpha1"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
+	natspkg "github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
+)
+
+// fakePipelineStorage captures status updates for assertions.
+type fakePipelineStorage struct {
+	mu      sync.Mutex
+	updates []pipelineStatusUpdate
+}
+
+type pipelineStatusUpdate struct {
+	pipelineID string
+	status     models.PipelineStatus
+	errors     []string
+	reason     string
+}
+
+func (f *fakePipelineStorage) UpdatePipelineStatus(_ context.Context, pipelineID string, status models.PipelineStatus, errs []string, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, pipelineStatusUpdate{
+		pipelineID: pipelineID,
+		status:     status,
+		errors:     append([]string(nil), errs...),
+		reason:     reason,
+	})
+	return nil
+}
+
+func (f *fakePipelineStorage) DeletePipeline(_ context.Context, _ string) error { return nil }
+
+func (f *fakePipelineStorage) snapshot() []pipelineStatusUpdate {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]pipelineStatusUpdate, len(f.updates))
+	copy(out, f.updates)
+	return out
+}
+
+func registerEtlScheme(t *testing.T) {
+	t.Helper()
+	if err := etlv1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		t.Fatalf("register etlv1alpha1 scheme: %v", err)
+	}
+}
+
+// expiredStartTime returns a timestamp far enough in the past that checkOperationTimeout
+// would deem any sane operation timed out.
+func expiredStartTime() string {
+	return time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+}
+
+// TestHandleOperationTimeoutStopRunsSweep covers the new Option A branch: when a stop
+// operation times out we still run the sweep + cleanup tail after force-terminating
+// components. Pipeline has no Source.Streams so buildNATSResourcePlan deterministically
+// errors inside sweepMessagesToDLQ — that exercises the sweep-failure side of the
+// branch (Failed with the sweep error captured in storage) without needing live NATS.
+func TestHandleOperationTimeoutStopRunsSweep(t *testing.T) {
+	registerEtlScheme(t)
+
+	pipeline := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipe-stop",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineStopAnnotation:               "true",
+				constants.PipelineOperationStartTimeAnnotation: expiredStartTime(),
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID:     "pipe-stop-id",
+			Source: etlv1alpha1.Sources{Type: "kafka"},
+			Sink:   etlv1alpha1.Sink{Type: "clickhouse"},
+		},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusStopping),
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(pipeline).
+		WithStatusSubresource(&etlv1alpha1.Pipeline{}).
+		Build()
+
+	storage := &fakePipelineStorage{}
+	r := &PipelineReconciler{
+		Client:          c,
+		Scheme:          scheme.Scheme,
+		NATSClient:      &natspkg.NATSClient{},
+		PostgresStorage: storage,
+	}
+
+	if _, err := r.handleOperationTimeout(context.Background(), logr.Discard(), pipeline); err != nil {
+		t.Fatalf("handleOperationTimeout returned error: %v", err)
+	}
+
+	var stored etlv1alpha1.Pipeline
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}, &stored); err != nil {
+		t.Fatalf("read back pipeline: %v", err)
+	}
+
+	if stored.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusFailed) {
+		t.Fatalf("status = %q, want %q (sweep failed, so stop tail must mark Failed)",
+			stored.Status, models.PipelineStatusFailed)
+	}
+	if _, exists := stored.Annotations[constants.PipelineStopAnnotation]; exists {
+		t.Fatalf("stop annotation was not cleared")
+	}
+	if _, exists := stored.Annotations[constants.PipelineOperationStartTimeAnnotation]; exists {
+		t.Fatalf("operation start time annotation was not cleared")
+	}
+
+	updates := storage.snapshot()
+	// Stop must NOT pre-emit a generic timeout Failed update — that's the old behavior the
+	// Option A change removed so we don't briefly publish Failed before Stopped.
+	for _, u := range updates {
+		if u.reason == "timeout" && len(u.errors) > 0 &&
+			strings.Contains(u.errors[0], "operation timed out") {
+			t.Fatalf("stop op emitted up-front timeout Failed update; updates=%+v", updates)
+		}
+	}
+	// We expect a Failed update whose error message names the sweep failure.
+	matched := false
+	for _, u := range updates {
+		if u.status == models.PipelineStatusFailed {
+			for _, e := range u.errors {
+				if strings.Contains(e, "forced stop sweep failed") {
+					matched = true
+				}
+			}
+		}
+	}
+	if !matched {
+		t.Fatalf("expected a Failed update mentioning 'forced stop sweep failed'; updates=%+v", updates)
+	}
+}
+
+// TestHandleOperationTimeoutNonStopMarksFailedUpFront guards the existing behavior for
+// non-stop operations: status flips to Failed before terminate, no forced-stop branch
+// fires (no sweep/cleanup attempted).
+func TestHandleOperationTimeoutNonStopMarksFailedUpFront(t *testing.T) {
+	registerEtlScheme(t)
+
+	pipeline := &etlv1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipe-edit",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.PipelineEditAnnotation:               "true",
+				constants.PipelineOperationStartTimeAnnotation: expiredStartTime(),
+			},
+		},
+		Spec: etlv1alpha1.PipelineSpec{
+			ID:     "pipe-edit-id",
+			Source: etlv1alpha1.Sources{Type: "kafka"},
+			Sink:   etlv1alpha1.Sink{Type: "clickhouse"},
+		},
+		Status: etlv1alpha1.PipelineStatus(models.PipelineStatusRunning),
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(pipeline).
+		WithStatusSubresource(&etlv1alpha1.Pipeline{}).
+		Build()
+
+	storage := &fakePipelineStorage{}
+	r := &PipelineReconciler{
+		Client:          c,
+		Scheme:          scheme.Scheme,
+		NATSClient:      &natspkg.NATSClient{},
+		PostgresStorage: storage,
+	}
+
+	if _, err := r.handleOperationTimeout(context.Background(), logr.Discard(), pipeline); err != nil {
+		t.Fatalf("handleOperationTimeout returned error: %v", err)
+	}
+
+	var stored etlv1alpha1.Pipeline
+	if err := c.Get(context.Background(), types.NamespacedName{Name: pipeline.Name, Namespace: pipeline.Namespace}, &stored); err != nil {
+		t.Fatalf("read back pipeline: %v", err)
+	}
+
+	if stored.Status != etlv1alpha1.PipelineStatus(models.PipelineStatusFailed) {
+		t.Fatalf("status = %q, want Failed", stored.Status)
+	}
+	if _, exists := stored.Annotations[constants.PipelineEditAnnotation]; exists {
+		t.Fatalf("edit annotation was not cleared")
+	}
+
+	updates := storage.snapshot()
+	// Non-stop ops must still emit the generic timeout Failed update.
+	foundTimeout := false
+	for _, u := range updates {
+		if u.reason == "timeout" && u.status == models.PipelineStatusFailed {
+			foundTimeout = true
+		}
+		for _, e := range u.errors {
+			if strings.Contains(e, "forced stop") {
+				t.Fatalf("non-stop op unexpectedly hit forced-stop branch; updates=%+v", updates)
+			}
+		}
+	}
+	if !foundTimeout {
+		t.Fatalf("expected a timeout Failed update for non-stop op; updates=%+v", updates)
+	}
+}

--- a/internal/controller/timeout_unit_test.go
+++ b/internal/controller/timeout_unit_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/constants"
 )
 
+func TestOperationTimeoutFor(t *testing.T) {
+	t.Parallel()
+
+	// Save and restore the package-level timeouts so this test stays isolated.
+	prevReconcile, prevStop := constants.ReconcileTimeout, constants.StopReconcileTimeout
+	constants.ReconcileTimeout = 17 * time.Minute
+	constants.StopReconcileTimeout = 3 * time.Minute
+	t.Cleanup(func() {
+		constants.ReconcileTimeout = prevReconcile
+		constants.StopReconcileTimeout = prevStop
+	})
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        time.Duration
+	}{
+		{
+			name:        "stop op uses StopReconcileTimeout",
+			annotations: map[string]string{constants.PipelineStopAnnotation: "true"},
+			want:        3 * time.Minute,
+		},
+		{
+			name:        "non-stop op uses ReconcileTimeout",
+			annotations: map[string]string{constants.PipelineEditAnnotation: "true"},
+			want:        17 * time.Minute,
+		},
+		{
+			name:        "no operation annotation defaults to ReconcileTimeout",
+			annotations: nil,
+			want:        17 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := operationTimeoutFor(tt.annotations); got != tt.want {
+				t.Fatalf("operationTimeoutFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetPipelineOperationFromAnnotations(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

  - `handleOperationTimeout` is now operation-aware. On stop timeout, after force-terminating components it runs `sweepMessagesToDLQ` +
   `cleanupNATSPipelineResourcesKeepDLQ` and ends in `Stopped`. Sweep/cleanup errors keep the pipeline `Failed` with the specific error
   recorded against PostgreSQL.
  - Added `--stop-reconcile-timeout` / `STOP_RECONCILE_TIMEOUT`, default **5 min** (vs. 15 min for other operations).
  `tryExtendStopTimeout` still extends while pending is decreasing, so legitimately-draining pipelines aren't capped.
  - Non-stop operations behave exactly as before.

  ## Behavior change

  A timed-out stop now ends in `Stopped` (orphans tagged `RetryExhaustedOnStop` in DLQ) instead of `Failed`. Operators using `Failed`
  as the stuck-stop signal should switch to DLQ depth or `gfm_operator_orphan_sweep_total{outcome="swept"}`.