### PR TITLE
feat: emit backpressure notification without stopping pipeline (ETL-1054)

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -84,6 +84,11 @@ const (
 	OperatorConsumer       = "operator-consumer"
 )
 
+// Component signal reason constants
+const (
+	ReasonBackpressure = "stream back-pressure"
+)
+
 // Component secrets created in pipeline namespace (same DB/encryption as API)
 const (
 	ComponentDatabaseSecretName   = "glassflow-component-database-url"

--- a/internal/consumers/component_signals_consumer.go
+++ b/internal/consumers/component_signals_consumer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/errs"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/models"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/nats"
+	"github.com/glassflow/glassflow-etl-k8s-operator/internal/notifications"
 	"github.com/glassflow/glassflow-etl-k8s-operator/internal/storage/postgres"
 )
 
@@ -93,16 +94,23 @@ func (c *ComponentSignalsConsumer) handleMessage(ctx context.Context, msg jetstr
 	}
 
 	c.log.Info(
-		"stopping pipeline",
-		"pipeline_id",
-		message.PipelineID,
-		"reason",
-		message.Reason,
-		"text",
-		message.Text,
-		"component",
-		message.Component,
+		"received component signal",
+		"pipeline_id", message.PipelineID,
+		"reason", message.Reason,
+		"text", message.Text,
+		"component", message.Component,
 	)
+
+	if message.Reason == constants.ReasonBackpressure {
+		notif := notifications.NewPipelineBackpressureNotification(message.PipelineID, nil)
+		if err := notifications.Publish(ctx, notif); err != nil {
+			c.log.Error(err, "failed to publish backpressure notification", "pipeline_id", message.PipelineID)
+		}
+		if err := msg.Ack(); err != nil {
+			c.log.Error(err, "failed to ack message")
+		}
+		return
+	}
 
 	err = c.stopPipeline(ctx, message)
 	if err != nil {

--- a/internal/notifications/builder.go
+++ b/internal/notifications/builder.go
@@ -161,3 +161,16 @@ func NewPipelineFailedNotification(pipelineID, title, message string, metadata m
 
 	return notification
 }
+
+// NewPipelineBackpressureNotification creates a notification for a pipeline back-pressure event.
+func NewPipelineBackpressureNotification(pipelineID string, metadata map[string]interface{}) *Notification {
+	return newPipelineNotification(
+		pipelineID,
+		SeverityWarning,
+		EventTypePipelineBackpressure,
+		"Pipeline Back-Pressure Detected",
+		"Your OTLP pipeline is under back-pressure — the stream buffer is full. Scale up your sink to resume normal ingestion.",
+		[]string{"backpressure"},
+		metadata,
+	)
+}

--- a/internal/notifications/types.go
+++ b/internal/notifications/types.go
@@ -32,6 +32,8 @@ const (
 	EventTypePipelineDeleted EventType = "pipeline_deleted"
 	// EventTypePipelineFailed indicates a pipeline failed
 	EventTypePipelineFailed EventType = "pipeline_failed"
+	// EventTypePipelineBackpressure indicates a pipeline is experiencing back-pressure
+	EventTypePipelineBackpressure EventType = "pipeline_backpressure"
 )
 
 // Metadata contains additional metadata for a notification


### PR DESCRIPTION
## Summary

- When the OTLP receiver detects sustained back-pressure, it emits a component signal — the operator should notify the user without stopping the pipeline ([ETL-1054](https://linear.app/glassflow/issue/ETL-1054/ui-show-back-pressure-notification-in-pipeline-view-with-scale))
- Previously, all component signals triggered a pipeline stop; backpressure is a transient condition that should surface as a warning notification only

## Changes

- `constants`: added `ReasonBackpressure = "stream back-pressure"` constant matching what the ETL processor emits
- `notifications`: added `EventTypePipelineBackpressure` event type and `NewPipelineBackpressureNotification` builder with the message: *"Your OTLP pipeline is under back-pressure — the stream buffer is full. Scale up your sink to resume normal ingestion."*
- `component_signals_consumer`: backpressure signals now publish a notification and ack without stopping the pipeline; all other signals continue to trigger a stop

## Test plan

- [ ] `make build` passes
- [ ] Send a component signal with `reason: "stream back-pressure"` — verify notification is published and pipeline remains running
- [ ] Send a component signal with any other reason — verify pipeline is stopped as before

## Rollback

Revert PR.